### PR TITLE
Update PAPLJ.full to new DynSem sort alias syntax

### DIFF
--- a/languages/paplj/paplj.full/.settings/org.eclipse.core.resources.prefs
+++ b/languages/paplj/paplj.full/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/A_Expr.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/A_Expr.java
@@ -4,7 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 
 public abstract class A_Expr extends AbstractNode implements IMatchableNode
 { 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
     throw new InterpreterException("Rule failure", "default", this);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/A_Program.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/A_Program.java
@@ -1,9 +1,25 @@
 package ds.generated.interpreter;
 
 import org.metaborg.meta.interpreter.framework.*;
+import com.github.krukow.clj_lang.PersistentTreeMap;
 
 public abstract class A_Program extends AbstractNode implements IMatchableNode
 { 
+  public R_init_V exec_init()
+  { 
+    this.specializeChildren(0);
+    final A_Program p382000004 = this;
+    final com.github.krukow.clj_ds.PersistentMap<?, ?> lifted_9290004 = (com.github.krukow.clj_ds.PersistentMap<?, ?>)PersistentTreeMap.EMPTY;
+    final com.github.krukow.clj_ds.PersistentMap<?, ?> lifted_9300004 = (com.github.krukow.clj_ds.PersistentMap<?, ?>)PersistentTreeMap.EMPTY;
+    final A_This lifted_9310004 = ds.manual.interpreter.Natives.mkNullThis_0();
+    final com.github.krukow.clj_ds.PersistentMap<?, ?> lifted_9320004 = (com.github.krukow.clj_ds.PersistentMap<?, ?>)PersistentTreeMap.EMPTY;
+    final R_default_V $tmp208 = p382000004.exec_default((com.github.krukow.clj_ds.PersistentMap<String, A_Class>)lifted_9290004, (com.github.krukow.clj_ds.PersistentMap<String, A_V>)lifted_9300004, lifted_9310004, (com.github.krukow.clj_ds.PersistentMap<Integer, A_V>)lifted_9320004);
+    final A_V v1125000004 = $tmp208.value;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> lifted_7500004 = $tmp208.get_1();
+    final A_V result_out103 = v1125000004;
+    return new R_init_V(result_out103);
+  }
+
   public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/A_Program.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/A_Program.java
@@ -4,7 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 
 public abstract class A_Program extends AbstractNode implements IMatchableNode
 { 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
     throw new InterpreterException("Rule failure", "default", this);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/A_allocate__Arrow.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/A_allocate__Arrow.java
@@ -4,7 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 
 public abstract class A_allocate__Arrow extends AbstractNode implements IMatchableNode
 { 
-  public R_default_Int exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_Int exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
     throw new InterpreterException("Rule failure", "default", this);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/A_bindVar__Arrow.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/A_bindVar__Arrow.java
@@ -4,7 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 
 public abstract class A_bindVar__Arrow extends AbstractNode implements IMatchableNode
 { 
-  public R_default_Env exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_Map_String_V_ exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
     throw new InterpreterException("Rule failure", "default", this);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/A_bindVars__Arrow.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/A_bindVars__Arrow.java
@@ -4,7 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 
 public abstract class A_bindVars__Arrow extends AbstractNode implements IMatchableNode
 { 
-  public R_default_Env exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_Map_String_V_ exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
     throw new InterpreterException("Rule failure", "default", this);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/A_defaultValue__Arrow.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/A_defaultValue__Arrow.java
@@ -4,7 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 
 public abstract class A_defaultValue__Arrow extends AbstractNode implements IMatchableNode
 { 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
     throw new InterpreterException("Rule failure", "default", this);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/A_initClasses__Arrow.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/A_initClasses__Arrow.java
@@ -4,7 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 
 public abstract class A_initClasses__Arrow extends AbstractNode implements IMatchableNode
 { 
-  public R_default_C exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_Map_String_Class_ exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
     throw new InterpreterException("Rule failure", "default", this);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/A_initFields__Arrow.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/A_initFields__Arrow.java
@@ -4,7 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 
 public abstract class A_initFields__Arrow extends AbstractNode implements IMatchableNode
 { 
-  public R_default_FM exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_Map_String_Int_ exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
     throw new InterpreterException("Rule failure", "default", this);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/A_initMethods__Arrow.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/A_initMethods__Arrow.java
@@ -4,7 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 
 public abstract class A_initMethods__Arrow extends AbstractNode implements IMatchableNode
 { 
-  public R_default_MM exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_Map_String_Method_ exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
     throw new InterpreterException("Rule failure", "default", this);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/A_initObject__Arrow.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/A_initObject__Arrow.java
@@ -4,7 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 
 public abstract class A_initObject__Arrow extends AbstractNode implements IMatchableNode
 { 
-  public R_default_Obj exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_Obj exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
     throw new InterpreterException("Rule failure", "default", this);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/A_initSuper__Arrow.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/A_initSuper__Arrow.java
@@ -4,7 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 
 public abstract class A_initSuper__Arrow extends AbstractNode implements IMatchableNode
 { 
-  public R_default_Super exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_Super exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
     throw new InterpreterException("Rule failure", "default", this);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/A_loadClass__Arrow.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/A_loadClass__Arrow.java
@@ -4,7 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 
 public abstract class A_loadClass__Arrow extends AbstractNode implements IMatchableNode
 { 
-  public R_default_Class exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_Class exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
     throw new InterpreterException("Rule failure", "default", this);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/A_lookupField__Arrow.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/A_lookupField__Arrow.java
@@ -4,7 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 
 public abstract class A_lookupField__Arrow extends AbstractNode implements IMatchableNode
 { 
-  public R_default_Int exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_Int exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
     throw new InterpreterException("Rule failure", "default", this);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/A_lookupMethod__Arrow.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/A_lookupMethod__Arrow.java
@@ -4,7 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 
 public abstract class A_lookupMethod__Arrow extends AbstractNode implements IMatchableNode
 { 
-  public R_default_Method exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_Method exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
     throw new InterpreterException("Rule failure", "default", this);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/A_readField__Arrow.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/A_readField__Arrow.java
@@ -4,7 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 
 public abstract class A_readField__Arrow extends AbstractNode implements IMatchableNode
 { 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
     throw new InterpreterException("Rule failure", "default", this);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/A_readVar__Arrow.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/A_readVar__Arrow.java
@@ -4,7 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 
 public abstract class A_readVar__Arrow extends AbstractNode implements IMatchableNode
 { 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
     throw new InterpreterException("Rule failure", "default", this);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/A_read__Arrow.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/A_read__Arrow.java
@@ -4,7 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 
 public abstract class A_read__Arrow extends AbstractNode implements IMatchableNode
 { 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
     throw new InterpreterException("Rule failure", "default", this);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/A_writeField__Arrow.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/A_writeField__Arrow.java
@@ -4,7 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 
 public abstract class A_writeField__Arrow extends AbstractNode implements IMatchableNode
 { 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
     throw new InterpreterException("Rule failure", "default", this);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/A_write__Arrow.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/A_write__Arrow.java
@@ -4,7 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 
 public abstract class A_write__Arrow extends AbstractNode implements IMatchableNode
 { 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
     throw new InterpreterException("Rule failure", "default", this);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Add_2.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Add_2.java
@@ -77,39 +77,39 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in20400 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in28500 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in28500 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in28500 = _4;
-    final A_Expr lifted_20520000 = this._1;
-    final A_Expr lifted_20530000 = this._2;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in23900 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in26100 = _2;
+    final A_This this_in22800 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in26100 = _4;
+    final A_Expr lifted_45210000 = this._1;
+    final A_Expr lifted_45220000 = this._2;
     { 
-      final A_This this_121500 = this_in20400;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_129100 = env_in28500;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_134100 = c_in28500;
-      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_129100 = store_in28500;
-      final R_default_V $tmp575 = lifted_20520000.exec_default(this_121500, env_129100, c_134100, store_129100);
-      final A_V lifted_2177000 = $tmp575.value;
-      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_220700 = $tmp575.get_1();
-      final NumV_1 $tmp576 = lifted_2177000.match(NumV_1.class);
-      if($tmp576 != null)
+      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_125000 = l_string_class_in23900;
+      final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_126500 = l_string_v_in26100;
+      final A_This this_123700 = this_in22800;
+      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_126500 = l_int_v_in26100;
+      final R_default_V $tmp1039 = lifted_45210000.exec_default(l_string_class_125000, l_string_v_126500, this_123700, l_int_v_126500);
+      final A_V lifted_4638000 = $tmp1039.value;
+      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_219600 = $tmp1039.get_1();
+      final NumV_1 $tmp1040 = lifted_4638000.match(NumV_1.class);
+      if($tmp1040 != null)
       { 
-        final int i6900000 = $tmp576.get_1();
-        final R_default_V $tmp577 = lifted_20530000.exec_default(this_121500, env_129100, c_134100, store_220700);
-        final A_V lifted_2176000 = $tmp577.value;
-        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_313100 = $tmp577.get_1();
-        final NumV_1 $tmp578 = lifted_2176000.match(NumV_1.class);
-        if($tmp578 != null)
+        final int i513000000 = $tmp1040.get_1();
+        final R_default_V $tmp1041 = lifted_45220000.exec_default(l_string_class_125000, l_string_v_126500, this_123700, l_int_v_219600);
+        final A_V lifted_4637000 = $tmp1041.value;
+        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_312300 = $tmp1041.get_1();
+        final NumV_1 $tmp1042 = lifted_4637000.match(NumV_1.class);
+        if($tmp1042 != null)
         { 
-          final int j4600000 = $tmp578.get_1();
-          final int lifted_20550000 = ds.manual.interpreter.Natives.plusI_2(i6900000, j4600000);
-          final NumV_1 lifted_20540000 = new NumV_1(this.getSourceInfo(), lifted_20550000);
-          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out28500 = store_313100;
-          final A_V result_out28500 = lifted_20540000;
-          return new R_default_V(result_out28500, store_out28500);
+          final int j265000000 = $tmp1042.get_1();
+          final int lifted_45240000 = ds.manual.interpreter.Natives.plusI_2(i513000000, j265000000);
+          final NumV_1 lifted_45230000 = new NumV_1(this.getSourceInfo(), lifted_45240000);
+          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out26000 = l_int_v_312300;
+          final A_V result_out53800 = lifted_45230000;
+          return new R_default_V(result_out53800, l_int_v_out26000);
         }
         else
         { }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/And_2.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/And_2.java
@@ -77,45 +77,45 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in21200 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in29200 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in29200 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in29200 = _4;
-    final A_Expr lifted_20470000 = this._1;
-    final A_Expr e7600000 = this._2;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in24500 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in26700 = _2;
+    final A_This this_in23600 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in26700 = _4;
+    final A_Expr lifted_45170000 = this._1;
+    final A_Expr e532000000 = this._2;
     { 
-      final A_This this_122200 = this_in21200;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_129700 = env_in29200;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_134800 = c_in29200;
-      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_129700 = store_in29200;
-      final R_default_V $tmp589 = lifted_20470000.exec_default(this_122200, env_129700, c_134800, store_129700);
-      final A_V lifted_2173000 = $tmp589.value;
-      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_221300 = $tmp589.get_1();
-      final BoolV_1 $tmp590 = lifted_2173000.match(BoolV_1.class);
-      if($tmp590 != null)
+      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_125600 = l_string_class_in24500;
+      final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_127100 = l_string_v_in26700;
+      final A_This this_124400 = this_in23600;
+      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_127100 = l_int_v_in26700;
+      final R_default_V $tmp1053 = lifted_45170000.exec_default(l_string_class_125600, l_string_v_127100, this_124400, l_int_v_127100);
+      final A_V lifted_4634000 = $tmp1053.value;
+      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_220000 = $tmp1053.get_1();
+      final BoolV_1 $tmp1054 = lifted_4634000.match(BoolV_1.class);
+      if($tmp1054 != null)
       { 
-        final boolean lifted_20480000 = $tmp590.get_1();
-        if(lifted_20480000 == false)
+        final boolean lifted_45180000 = $tmp1054.get_1();
+        if(lifted_45180000 == false)
         { 
-          final boolean lifted_20460000 = false;
-          final BoolV_1 lifted_20440000 = new BoolV_1(this.getSourceInfo(), lifted_20460000);
-          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out29200 = store_221300;
-          final A_V result_out29200 = lifted_20440000;
-          return new R_default_V(result_out29200, store_out29200);
+          final boolean lifted_45160000 = false;
+          final BoolV_1 lifted_45140000 = new BoolV_1(this.getSourceInfo(), lifted_45160000);
+          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out26600 = l_int_v_220000;
+          final A_V result_out54400 = lifted_45140000;
+          return new R_default_V(result_out54400, l_int_v_out26600);
         }
         else
         { 
-          if(lifted_20480000 == true)
+          if(lifted_45180000 == true)
           { 
-            final R_default_V $tmp591 = e7600000.exec_default(this_122200, env_129700, c_134800, store_221300);
-            final A_V lifted_2174000 = $tmp591.value;
-            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_313400 = $tmp591.get_1();
-            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out29200 = store_313400;
-            final A_V result_out29200 = lifted_2174000;
-            return new R_default_V(result_out29200, store_out29200);
+            final R_default_V $tmp1055 = e532000000.exec_default(l_string_class_125600, l_string_v_127100, this_124400, l_int_v_220000);
+            final A_V lifted_4635000 = $tmp1055.value;
+            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_312600 = $tmp1055.get_1();
+            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out26600 = l_int_v_312600;
+            final A_V result_out54400 = lifted_4635000;
+            return new R_default_V(result_out54400, l_int_v_out26600);
           }
           else
           { }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/AutoMapUtils.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/AutoMapUtils.java
@@ -11,228 +11,198 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
 
 public class AutoMapUtils  
 { 
-  public static IStrategoTerm toStrategoTerm_C(PersistentMap<String, A_Class> map, ITermFactory factory)
+  public static IStrategoTerm map_String_int2aterm(PersistentMap<String, Integer> map, ITermFactory factory)
   { 
     IStrategoConstructor bindCons = factory.makeConstructor("Bind", 2);
     IStrategoTerm[] kids = new IStrategoTerm[map.size() + 1];
-    kids[0] = factory.makeString("C");
-    int idx = 1;
-    for(Entry<String, A_Class> entry : map.entrySet())
-    { 
-      kids[idx] = factory.makeAppl(bindCons, factory.makeString(entry.getKey()), entry.getValue().toStrategoTerm(factory));
-      idx++;
-    }
-    return factory.makeAppl(factory.makeConstructor("Map", 2), kids);
-  }
-
-  public static PersistentMap<String, A_Class> to_C(IStrategoTerm term)
-  { 
-    final String mapName = "C";
-    final Map<String, A_Class> result = new TreeMap<String, A_Class>();
-    if(Tools.isTermAppl(term))
-    { 
-      IStrategoAppl appl = (IStrategoAppl)term;
-      if(Tools.hasConstructor(appl, "Map", 2))
-      { 
-        IStrategoTerm kid0 = term.getSubterm(0);
-        if(Tools.isTermString(kid0) && Tools.asJavaString(kid0).equals(mapName))
-        { 
-          for(int idx = 1; idx < term.getSubtermCount(); idx++)
-          { 
-            IStrategoTerm kid = term.getSubterm(idx);
-            if(Tools.isTermAppl(kid))
-            { 
-              IStrategoAppl bindAppl = (IStrategoAppl)kid;
-              if(Tools.hasConstructor(bindAppl, "Bind", 2))
-              { 
-                result.put(Tools.asJavaString(bindAppl.getSubterm(0)), new Generic_A_Class(NodeSource.fromStrategoTerm(bindAppl.getSubterm(1)), bindAppl.getSubterm(1)));
-              }
-            }
-          }
-          return PersistentTreeMap.create(result);
-        }
-      }
-    }
-    throw new RuntimeException("Malformed map for " + mapName);
-  }
-
-  public static IStrategoTerm toStrategoTerm_FM(PersistentMap<String, Integer> map, ITermFactory factory)
-  { 
-    IStrategoConstructor bindCons = factory.makeConstructor("Bind", 2);
-    IStrategoTerm[] kids = new IStrategoTerm[map.size() + 1];
-    kids[0] = factory.makeString("FM");
-    int idx = 1;
+    int idx = 0;
     for(Entry<String, Integer> entry : map.entrySet())
     { 
-      kids[idx] = factory.makeAppl(bindCons, factory.makeString(entry.getKey()), factory.makeInt(entry.getValue()));
+      kids[idx] = factory.makeAppl(bindCons, TermUtils.termFromString(entry.getKey(), factory), TermUtils.termFromInt(entry.getValue(), factory));
       idx++;
     }
     return factory.makeAppl(factory.makeConstructor("Map", 2), kids);
   }
 
-  public static PersistentMap<String, Integer> to_FM(IStrategoTerm term)
+  public static com.github.krukow.clj_ds.PersistentMap<String, Integer> aterm2map_String_int(IStrategoTerm term)
   { 
-    final String mapName = "FM";
     final Map<String, Integer> result = new TreeMap<String, Integer>();
     if(Tools.isTermAppl(term))
     { 
       IStrategoAppl appl = (IStrategoAppl)term;
       if(Tools.hasConstructor(appl, "Map", 2))
       { 
-        IStrategoTerm kid0 = term.getSubterm(0);
-        if(Tools.isTermString(kid0) && Tools.asJavaString(kid0).equals(mapName))
+        for(int idx = 1; idx < term.getSubtermCount(); idx++)
         { 
-          for(int idx = 1; idx < term.getSubtermCount(); idx++)
+          IStrategoTerm kid = term.getSubterm(idx);
+          if(Tools.isTermAppl(kid))
           { 
-            IStrategoTerm kid = term.getSubterm(idx);
-            if(Tools.isTermAppl(kid))
+            IStrategoAppl bindAppl = (IStrategoAppl)kid;
+            if(Tools.hasConstructor(bindAppl, "Bind", 2))
             { 
-              IStrategoAppl bindAppl = (IStrategoAppl)kid;
-              if(Tools.hasConstructor(bindAppl, "Bind", 2))
-              { 
-                result.put(Tools.asJavaString(bindAppl.getSubterm(0)), Tools.asJavaInt(bindAppl.getSubterm(1)));
-              }
+              result.put(TermUtils.stringFromTerm(bindAppl.getSubterm(0)), TermUtils.intFromTerm(bindAppl.getSubterm(1)));
             }
           }
-          return PersistentTreeMap.create(result);
         }
+        return PersistentTreeMap.create(result);
       }
     }
-    throw new RuntimeException("Malformed map for " + mapName);
+    throw new RewritingException("Malformed map");
   }
 
-  public static IStrategoTerm toStrategoTerm_MM(PersistentMap<String, A_Method> map, ITermFactory factory)
+  public static IStrategoTerm map_String_A_Method2aterm(PersistentMap<String, A_Method> map, ITermFactory factory)
   { 
     IStrategoConstructor bindCons = factory.makeConstructor("Bind", 2);
     IStrategoTerm[] kids = new IStrategoTerm[map.size() + 1];
-    kids[0] = factory.makeString("MM");
-    int idx = 1;
+    int idx = 0;
     for(Entry<String, A_Method> entry : map.entrySet())
     { 
-      kids[idx] = factory.makeAppl(bindCons, factory.makeString(entry.getKey()), entry.getValue().toStrategoTerm(factory));
+      kids[idx] = factory.makeAppl(bindCons, TermUtils.termFromString(entry.getKey(), factory), entry.getValue().toStrategoTerm(factory));
       idx++;
     }
     return factory.makeAppl(factory.makeConstructor("Map", 2), kids);
   }
 
-  public static PersistentMap<String, A_Method> to_MM(IStrategoTerm term)
+  public static com.github.krukow.clj_ds.PersistentMap<String, A_Method> aterm2map_String_A_Method(IStrategoTerm term)
   { 
-    final String mapName = "MM";
     final Map<String, A_Method> result = new TreeMap<String, A_Method>();
     if(Tools.isTermAppl(term))
     { 
       IStrategoAppl appl = (IStrategoAppl)term;
       if(Tools.hasConstructor(appl, "Map", 2))
       { 
-        IStrategoTerm kid0 = term.getSubterm(0);
-        if(Tools.isTermString(kid0) && Tools.asJavaString(kid0).equals(mapName))
+        for(int idx = 1; idx < term.getSubtermCount(); idx++)
         { 
-          for(int idx = 1; idx < term.getSubtermCount(); idx++)
+          IStrategoTerm kid = term.getSubterm(idx);
+          if(Tools.isTermAppl(kid))
           { 
-            IStrategoTerm kid = term.getSubterm(idx);
-            if(Tools.isTermAppl(kid))
+            IStrategoAppl bindAppl = (IStrategoAppl)kid;
+            if(Tools.hasConstructor(bindAppl, "Bind", 2))
             { 
-              IStrategoAppl bindAppl = (IStrategoAppl)kid;
-              if(Tools.hasConstructor(bindAppl, "Bind", 2))
-              { 
-                result.put(Tools.asJavaString(bindAppl.getSubterm(0)), new Generic_A_Method(NodeSource.fromStrategoTerm(bindAppl.getSubterm(1)), bindAppl.getSubterm(1)));
-              }
+              result.put(TermUtils.stringFromTerm(bindAppl.getSubterm(0)), new Generic_A_Method(NodeSource.fromStrategoTerm(bindAppl.getSubterm(1)), bindAppl.getSubterm(1)).specialize(1));
             }
           }
-          return PersistentTreeMap.create(result);
         }
+        return PersistentTreeMap.create(result);
       }
     }
-    throw new RuntimeException("Malformed map for " + mapName);
+    throw new RewritingException("Malformed map");
   }
 
-  public static IStrategoTerm toStrategoTerm_Env(PersistentMap<String, A_V> map, ITermFactory factory)
+  public static IStrategoTerm map_String_A_Class2aterm(PersistentMap<String, A_Class> map, ITermFactory factory)
   { 
     IStrategoConstructor bindCons = factory.makeConstructor("Bind", 2);
     IStrategoTerm[] kids = new IStrategoTerm[map.size() + 1];
-    kids[0] = factory.makeString("Env");
-    int idx = 1;
-    for(Entry<String, A_V> entry : map.entrySet())
+    int idx = 0;
+    for(Entry<String, A_Class> entry : map.entrySet())
     { 
-      kids[idx] = factory.makeAppl(bindCons, factory.makeString(entry.getKey()), entry.getValue().toStrategoTerm(factory));
+      kids[idx] = factory.makeAppl(bindCons, TermUtils.termFromString(entry.getKey(), factory), entry.getValue().toStrategoTerm(factory));
       idx++;
     }
     return factory.makeAppl(factory.makeConstructor("Map", 2), kids);
   }
 
-  public static PersistentMap<String, A_V> to_Env(IStrategoTerm term)
+  public static com.github.krukow.clj_ds.PersistentMap<String, A_Class> aterm2map_String_A_Class(IStrategoTerm term)
   { 
-    final String mapName = "Env";
+    final Map<String, A_Class> result = new TreeMap<String, A_Class>();
+    if(Tools.isTermAppl(term))
+    { 
+      IStrategoAppl appl = (IStrategoAppl)term;
+      if(Tools.hasConstructor(appl, "Map", 2))
+      { 
+        for(int idx = 1; idx < term.getSubtermCount(); idx++)
+        { 
+          IStrategoTerm kid = term.getSubterm(idx);
+          if(Tools.isTermAppl(kid))
+          { 
+            IStrategoAppl bindAppl = (IStrategoAppl)kid;
+            if(Tools.hasConstructor(bindAppl, "Bind", 2))
+            { 
+              result.put(TermUtils.stringFromTerm(bindAppl.getSubterm(0)), new Generic_A_Class(NodeSource.fromStrategoTerm(bindAppl.getSubterm(1)), bindAppl.getSubterm(1)).specialize(1));
+            }
+          }
+        }
+        return PersistentTreeMap.create(result);
+      }
+    }
+    throw new RewritingException("Malformed map");
+  }
+
+  public static IStrategoTerm map_String_A_V2aterm(PersistentMap<String, A_V> map, ITermFactory factory)
+  { 
+    IStrategoConstructor bindCons = factory.makeConstructor("Bind", 2);
+    IStrategoTerm[] kids = new IStrategoTerm[map.size() + 1];
+    int idx = 0;
+    for(Entry<String, A_V> entry : map.entrySet())
+    { 
+      kids[idx] = factory.makeAppl(bindCons, TermUtils.termFromString(entry.getKey(), factory), entry.getValue().toStrategoTerm(factory));
+      idx++;
+    }
+    return factory.makeAppl(factory.makeConstructor("Map", 2), kids);
+  }
+
+  public static com.github.krukow.clj_ds.PersistentMap<String, A_V> aterm2map_String_A_V(IStrategoTerm term)
+  { 
     final Map<String, A_V> result = new TreeMap<String, A_V>();
     if(Tools.isTermAppl(term))
     { 
       IStrategoAppl appl = (IStrategoAppl)term;
       if(Tools.hasConstructor(appl, "Map", 2))
       { 
-        IStrategoTerm kid0 = term.getSubterm(0);
-        if(Tools.isTermString(kid0) && Tools.asJavaString(kid0).equals(mapName))
+        for(int idx = 1; idx < term.getSubtermCount(); idx++)
         { 
-          for(int idx = 1; idx < term.getSubtermCount(); idx++)
+          IStrategoTerm kid = term.getSubterm(idx);
+          if(Tools.isTermAppl(kid))
           { 
-            IStrategoTerm kid = term.getSubterm(idx);
-            if(Tools.isTermAppl(kid))
+            IStrategoAppl bindAppl = (IStrategoAppl)kid;
+            if(Tools.hasConstructor(bindAppl, "Bind", 2))
             { 
-              IStrategoAppl bindAppl = (IStrategoAppl)kid;
-              if(Tools.hasConstructor(bindAppl, "Bind", 2))
-              { 
-                result.put(Tools.asJavaString(bindAppl.getSubterm(0)), new Generic_A_V(NodeSource.fromStrategoTerm(bindAppl.getSubterm(1)), bindAppl.getSubterm(1)));
-              }
+              result.put(TermUtils.stringFromTerm(bindAppl.getSubterm(0)), new Generic_A_V(NodeSource.fromStrategoTerm(bindAppl.getSubterm(1)), bindAppl.getSubterm(1)).specialize(1));
             }
           }
-          return PersistentTreeMap.create(result);
         }
+        return PersistentTreeMap.create(result);
       }
     }
-    throw new RuntimeException("Malformed map for " + mapName);
+    throw new RewritingException("Malformed map");
   }
 
-  public static IStrategoTerm toStrategoTerm_Store(PersistentMap<Integer, A_V> map, ITermFactory factory)
+  public static IStrategoTerm map_int_A_V2aterm(PersistentMap<Integer, A_V> map, ITermFactory factory)
   { 
     IStrategoConstructor bindCons = factory.makeConstructor("Bind", 2);
     IStrategoTerm[] kids = new IStrategoTerm[map.size() + 1];
-    kids[0] = factory.makeString("Store");
-    int idx = 1;
+    int idx = 0;
     for(Entry<Integer, A_V> entry : map.entrySet())
     { 
-      kids[idx] = factory.makeAppl(bindCons, factory.makeInt(entry.getKey()), entry.getValue().toStrategoTerm(factory));
+      kids[idx] = factory.makeAppl(bindCons, TermUtils.termFromInt(entry.getKey(), factory), entry.getValue().toStrategoTerm(factory));
       idx++;
     }
     return factory.makeAppl(factory.makeConstructor("Map", 2), kids);
   }
 
-  public static PersistentMap<Integer, A_V> to_Store(IStrategoTerm term)
+  public static com.github.krukow.clj_ds.PersistentMap<Integer, A_V> aterm2map_int_A_V(IStrategoTerm term)
   { 
-    final String mapName = "Store";
     final Map<Integer, A_V> result = new TreeMap<Integer, A_V>();
     if(Tools.isTermAppl(term))
     { 
       IStrategoAppl appl = (IStrategoAppl)term;
       if(Tools.hasConstructor(appl, "Map", 2))
       { 
-        IStrategoTerm kid0 = term.getSubterm(0);
-        if(Tools.isTermString(kid0) && Tools.asJavaString(kid0).equals(mapName))
+        for(int idx = 1; idx < term.getSubtermCount(); idx++)
         { 
-          for(int idx = 1; idx < term.getSubtermCount(); idx++)
+          IStrategoTerm kid = term.getSubterm(idx);
+          if(Tools.isTermAppl(kid))
           { 
-            IStrategoTerm kid = term.getSubterm(idx);
-            if(Tools.isTermAppl(kid))
+            IStrategoAppl bindAppl = (IStrategoAppl)kid;
+            if(Tools.hasConstructor(bindAppl, "Bind", 2))
             { 
-              IStrategoAppl bindAppl = (IStrategoAppl)kid;
-              if(Tools.hasConstructor(bindAppl, "Bind", 2))
-              { 
-                result.put(Tools.asJavaInt(bindAppl.getSubterm(0)), new Generic_A_V(NodeSource.fromStrategoTerm(bindAppl.getSubterm(1)), bindAppl.getSubterm(1)));
-              }
+              result.put(TermUtils.intFromTerm(bindAppl.getSubterm(0)), new Generic_A_V(NodeSource.fromStrategoTerm(bindAppl.getSubterm(1)), bindAppl.getSubterm(1)).specialize(1));
             }
           }
-          return PersistentTreeMap.create(result);
         }
+        return PersistentTreeMap.create(result);
       }
     }
-    throw new RuntimeException("Malformed map for " + mapName);
+    throw new RewritingException("Malformed map");
   }
 }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Bind_3.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Bind_3.java
@@ -109,7 +109,7 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)
   { 
-    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("Bind", 3), _1.toStrategoTerm(factory), factory.makeString(_2), _3.toStrategoTerm(factory));
+    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("Bind", 3), _1.toStrategoTerm(factory), TermUtils.termFromString(_2, factory), _3.toStrategoTerm(factory));
     if(getSourceInfo() != null)
     { 
       getSourceInfo().apply(term);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Call_3.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Call_3.java
@@ -100,57 +100,57 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in22400 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in30400 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in30400 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in30400 = _4;
-    final A_Expr lifted_20230000 = this._1;
-    final String m5400000 = this._2;
-    final L_A_Expr lifted_20240000 = this._3;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in25600 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in27800 = _2;
+    final A_This this_in24800 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in27800 = _4;
+    final A_Expr lifted_44930000 = this._1;
+    final String m175000000 = this._2;
+    final L_A_Expr lifted_44940000 = this._3;
     { 
-      final A_This this_123400 = this_in22400;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_130900 = env_in30400;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_136500 = c_in30400;
-      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_130900 = store_in30400;
-      final R_default_V $tmp627 = lifted_20230000.exec_default(this_123400, env_130900, c_136500, store_130900);
-      final A_V lifted_2169000 = $tmp627.value;
-      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_222600 = $tmp627.get_1();
-      final o2v_1 $tmp628 = lifted_2169000.match(o2v_1.class);
-      if($tmp628 != null)
+      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_126700 = l_string_class_in25600;
+      final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_128200 = l_string_v_in27800;
+      final A_This this_125600 = this_in24800;
+      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_128200 = l_int_v_in27800;
+      final R_default_V $tmp1091 = lifted_44930000.exec_default(l_string_class_126700, l_string_v_128200, this_125600, l_int_v_128200);
+      final A_V lifted_4631000 = $tmp1091.value;
+      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_221300 = $tmp1091.get_1();
+      final o2v_1 $tmp1092 = lifted_4631000.match(o2v_1.class);
+      if($tmp1092 != null)
       { 
-        final A_Obj o9300000 = $tmp628.get_1();
-        final R_default_List_V_ $tmp629 = lifted_20240000.exec_default(this_123400, env_130900, c_136500, store_222600);
-        final L_A_V vs2800000 = $tmp629.value;
-        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_314500 = $tmp629.get_1();
-        final lookupMethod_2 lifted_20250000 = new lookupMethod_2(this.getSourceInfo(), o9300000, m5400000);
-        final R_default_Method $tmp630 = lifted_20250000.exec_default(this_123400, env_130900, c_136500, store_314500);
-        final A_Method lifted_20260000 = $tmp630.value;
-        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_43300 = $tmp630.get_1();
-        final Method_4 $tmp631 = lifted_20260000.match(Method_4.class);
-        if($tmp631 != null)
+        final A_Obj o607000000 = $tmp1092.get_1();
+        final R_default_List_V_ $tmp1093 = lifted_44940000.exec_default(l_string_class_126700, l_string_v_128200, this_125600, l_int_v_221300);
+        final L_A_V vs149000000 = $tmp1093.value;
+        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_313800 = $tmp1093.get_1();
+        final lookupMethod_2 lifted_44950000 = new lookupMethod_2(this.getSourceInfo(), o607000000, m175000000);
+        final R_default_Method $tmp1094 = lifted_44950000.exec_default(l_string_class_126700, l_string_v_128200, this_125600, l_int_v_313800);
+        final A_Method lifted_44960000 = $tmp1094.value;
+        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_43100 = $tmp1094.get_1();
+        final Method_4 $tmp1095 = lifted_44960000.match(Method_4.class);
+        if($tmp1095 != null)
         { 
-          final A_Type lifted_18620000 = $tmp631.get_1();
-          final String lifted_18630000 = $tmp631.get_2();
-          final L_A_Param params2200000 = $tmp631.get_3();
-          final A_Block e7500000 = $tmp631.get_4();
-          final R_default_List_String_ $tmp632 = params2200000.exec_default(this_123400, env_130900, c_136500, store_43300);
-          final L_String lifted_2166000 = $tmp632.value;
-          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_5400 = $tmp632.get_1();
-          final bindVars_2 lifted_20270000 = new bindVars_2(this.getSourceInfo(), lifted_2166000, vs2800000);
-          final T_1 lifted_2159000 = new T_1(this.getSourceInfo(), o9300000);
-          final R_default_Env $tmp633 = lifted_20270000.exec_default(this_123400, env_130900, c_136500, store_5400);
-          final com.github.krukow.clj_ds.PersistentMap<String, A_V> lifted_2161000 = $tmp633.value;
-          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_6400 = $tmp633.get_1();
-          final block2expr_1 lifted_2162000 = new block2expr_1(this.getSourceInfo(), e7500000);
-          final R_default_V $tmp634 = lifted_2162000.exec_default(lifted_2159000, lifted_2161000, c_136500, store_6400);
-          final A_V v_1500000 = $tmp634.value;
-          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_7400 = $tmp634.get_1();
-          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out30400 = store_7400;
-          final A_V result_out30400 = v_1500000;
-          return new R_default_V(result_out30400, store_out30400);
+          final A_Type lifted_43430000 = $tmp1095.get_1();
+          final String lifted_43440000 = $tmp1095.get_2();
+          final L_A_Param params185000000 = $tmp1095.get_3();
+          final A_Block e531000000 = $tmp1095.get_4();
+          final R_default_List_String_ $tmp1096 = params185000000.exec_default(l_string_class_126700, l_string_v_128200, this_125600, l_int_v_43100);
+          final L_String lifted_4628000 = $tmp1096.value;
+          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_5400 = $tmp1096.get_1();
+          final bindVars_2 lifted_44970000 = new bindVars_2(this.getSourceInfo(), lifted_4628000, vs149000000);
+          final T_1 lifted_4622000 = new T_1(this.getSourceInfo(), o607000000);
+          final R_default_Map_String_V_ $tmp1097 = lifted_44970000.exec_default(l_string_class_126700, l_string_v_128200, this_125600, l_int_v_5400);
+          final com.github.krukow.clj_ds.PersistentMap<String, A_V> lifted_4623000 = $tmp1097.value;
+          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_6400 = $tmp1097.get_1();
+          final block2expr_1 lifted_4624000 = new block2expr_1(this.getSourceInfo(), e531000000);
+          final R_default_V $tmp1098 = lifted_4624000.exec_default(l_string_class_126700, lifted_4623000, lifted_4622000, l_int_v_6400);
+          final A_V v_123000000 = $tmp1098.value;
+          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_7400 = $tmp1098.get_1();
+          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out27700 = l_int_v_7400;
+          final A_V result_out55500 = v_123000000;
+          return new R_default_V(result_out55500, l_int_v_out27700);
         }
         else
         { }
@@ -180,7 +180,7 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)
   { 
-    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("Call", 3), _1.toStrategoTerm(factory), factory.makeString(_2), _3.toStrategoTerm(factory));
+    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("Call", 3), _1.toStrategoTerm(factory), TermUtils.termFromString(_2, factory), _3.toStrategoTerm(factory));
     if(getSourceInfo() != null)
     { 
       getSourceInfo().apply(term);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Cast_2.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Cast_2.java
@@ -73,7 +73,7 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
     return super.exec_default(_1, _2, _3, _4);
@@ -91,7 +91,7 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)
   { 
-    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("Cast", 2), factory.makeString(_1), _2.toStrategoTerm(factory));
+    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("Cast", 2), TermUtils.termFromString(_1, factory), _2.toStrategoTerm(factory));
     if(getSourceInfo() != null)
     { 
       getSourceInfo().apply(term);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/ClassT_1.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/ClassT_1.java
@@ -61,7 +61,7 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)
   { 
-    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("ClassT", 1), factory.makeString(_1));
+    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("ClassT", 1), TermUtils.termFromString(_1, factory));
     if(getSourceInfo() != null)
     { 
       getSourceInfo().apply(term);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Class_4.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Class_4.java
@@ -149,7 +149,7 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)
   { 
-    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("Class", 4), factory.makeString(_1), _2.toStrategoTerm(factory), _3.toStrategoTerm(factory), _4.toStrategoTerm(factory));
+    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("Class", 4), TermUtils.termFromString(_1, factory), _2.toStrategoTerm(factory), _3.toStrategoTerm(factory), _4.toStrategoTerm(factory));
     if(getSourceInfo() != null)
     { 
       getSourceInfo().apply(term);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Eq_2.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Eq_2.java
@@ -77,39 +77,39 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in21400 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in29400 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in29400 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in29400 = _4;
-    final A_Expr lifted_19990000 = this._1;
-    final A_Expr lifted_20010000 = this._2;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in24700 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in26900 = _2;
+    final A_This this_in23800 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in26900 = _4;
+    final A_Expr lifted_44720000 = this._1;
+    final A_Expr lifted_44730000 = this._2;
     { 
-      final A_This this_122400 = this_in21400;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_129900 = env_in29400;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_135100 = c_in29400;
-      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_129900 = store_in29400;
-      final R_default_V $tmp595 = lifted_19990000.exec_default(this_122400, env_129900, c_135100, store_129900);
-      final A_V lifted_2146000 = $tmp595.value;
-      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_221500 = $tmp595.get_1();
-      final NumV_1 $tmp596 = lifted_2146000.match(NumV_1.class);
-      if($tmp596 != null)
+      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_125800 = l_string_class_in24700;
+      final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_127300 = l_string_v_in26900;
+      final A_This this_124600 = this_in23800;
+      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_127300 = l_int_v_in26900;
+      final R_default_V $tmp1059 = lifted_44720000.exec_default(l_string_class_125800, l_string_v_127300, this_124600, l_int_v_127300);
+      final A_V lifted_4609000 = $tmp1059.value;
+      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_220200 = $tmp1059.get_1();
+      final NumV_1 $tmp1060 = lifted_4609000.match(NumV_1.class);
+      if($tmp1060 != null)
       { 
-        final int i6800000 = $tmp596.get_1();
-        final R_default_V $tmp597 = lifted_20010000.exec_default(this_122400, env_129900, c_135100, store_221500);
-        final A_V lifted_2145000 = $tmp597.value;
-        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_313600 = $tmp597.get_1();
-        final NumV_1 $tmp598 = lifted_2145000.match(NumV_1.class);
-        if($tmp598 != null)
+        final int i512000000 = $tmp1060.get_1();
+        final R_default_V $tmp1061 = lifted_44730000.exec_default(l_string_class_125800, l_string_v_127300, this_124600, l_int_v_220200);
+        final A_V lifted_4608000 = $tmp1061.value;
+        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_312800 = $tmp1061.get_1();
+        final NumV_1 $tmp1062 = lifted_4608000.match(NumV_1.class);
+        if($tmp1062 != null)
         { 
-          final int j4500000 = $tmp598.get_1();
-          final boolean lifted_20030000 = ds.manual.interpreter.Natives.eqI_2(i6800000, j4500000);
-          final BoolV_1 lifted_20020000 = new BoolV_1(this.getSourceInfo(), lifted_20030000);
-          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out29400 = store_313600;
-          final A_V result_out29400 = lifted_20020000;
-          return new R_default_V(result_out29400, store_out29400);
+          final int j264000000 = $tmp1062.get_1();
+          final boolean lifted_44750000 = ds.manual.interpreter.Natives.eqI_2(i512000000, j264000000);
+          final BoolV_1 lifted_44740000 = new BoolV_1(this.getSourceInfo(), lifted_44750000);
+          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out26800 = l_int_v_312800;
+          final A_V result_out54600 = lifted_44740000;
+          return new R_default_V(result_out54600, l_int_v_out26800);
         }
         else
         { }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Extends_1.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Extends_1.java
@@ -61,7 +61,7 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)
   { 
-    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("Extends", 1), factory.makeString(_1));
+    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("Extends", 1), TermUtils.termFromString(_1, factory));
     if(getSourceInfo() != null)
     { 
       getSourceInfo().apply(term);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/False_0.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/False_0.java
@@ -39,22 +39,22 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in20800 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in28900 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in28900 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in28900 = _4;
-    final A_This this_121900 = this_in20800;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_129500 = env_in28900;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_134500 = c_in28900;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_129500 = store_in28900;
-    final boolean lifted_19980000 = false;
-    final BoolV_1 lifted_19970000 = new BoolV_1(this.getSourceInfo(), lifted_19980000);
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out28900 = store_129500;
-    final A_V result_out28900 = lifted_19970000;
-    return new R_default_V(result_out28900, store_out28900);
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in24300 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in26500 = _2;
+    final A_This this_in23400 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in26500 = _4;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_125400 = l_string_class_in24300;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_126900 = l_string_v_in26500;
+    final A_This this_124200 = this_in23400;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_126900 = l_int_v_in26500;
+    final boolean lifted_44710000 = false;
+    final BoolV_1 lifted_44700000 = new BoolV_1(this.getSourceInfo(), lifted_44710000);
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out26400 = l_int_v_126900;
+    final A_V result_out54200 = lifted_44700000;
+    return new R_default_V(result_out54200, l_int_v_out26400);
   }
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Field_2.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Field_2.java
@@ -85,7 +85,7 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)
   { 
-    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("Field", 2), _1.toStrategoTerm(factory), factory.makeString(_2));
+    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("Field", 2), _1.toStrategoTerm(factory), TermUtils.termFromString(_2, factory));
     if(getSourceInfo() != null)
     { 
       getSourceInfo().apply(term);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_Bind.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_Bind.java
@@ -4,6 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 import org.spoofax.interpreter.terms.*;
 import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 import org.spoofax.interpreter.core.Tools;
+import java.util.Objects;
 
 @SuppressWarnings("unused") public class Generic_A_Bind extends A_Bind implements IGenericNode
 { 
@@ -11,6 +12,7 @@ import org.spoofax.interpreter.core.Tools;
 
   public Generic_A_Bind (INodeSource source, IStrategoTerm term) 
   { 
+    Objects.requireNonNull(term);
     this.setSourceInfo(source);
     this.aterm = term;
   }
@@ -38,7 +40,7 @@ import org.spoofax.interpreter.core.Tools;
       final INodeSource source = NodeSource.fromStrategoTerm(term);
       if(name.equals("Bind") && term.getSubtermCount() == 3)
       { 
-        A_Bind replacement = replace(new Bind_3(source, new Generic_A_Type(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)), Tools.asJavaString(term.getSubterm(1)), new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(2)), term.getSubterm(2))));
+        A_Bind replacement = replace(new Bind_3(source, new Generic_A_Type(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)).specialize(1), TermUtils.stringFromTerm(term.getSubterm(1)), new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(2)), term.getSubterm(2)).specialize(1)));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -46,7 +48,6 @@ import org.spoofax.interpreter.core.Tools;
         return replacement;
       }
     }
-    IGenericNode replacement = null;
     throw new RewritingException(aterm.toString());
   }
 

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_Block.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_Block.java
@@ -4,6 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 import org.spoofax.interpreter.terms.*;
 import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 import org.spoofax.interpreter.core.Tools;
+import java.util.Objects;
 
 @SuppressWarnings("unused") public class Generic_A_Block extends A_Block implements IGenericNode
 { 
@@ -11,6 +12,7 @@ import org.spoofax.interpreter.core.Tools;
 
   public Generic_A_Block (INodeSource source, IStrategoTerm term) 
   { 
+    Objects.requireNonNull(term);
     this.setSourceInfo(source);
     this.aterm = term;
   }
@@ -46,7 +48,6 @@ import org.spoofax.interpreter.core.Tools;
         return replacement;
       }
     }
-    IGenericNode replacement = null;
     throw new RewritingException(aterm.toString());
   }
 

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_Class.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_Class.java
@@ -4,6 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 import org.spoofax.interpreter.terms.*;
 import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 import org.spoofax.interpreter.core.Tools;
+import java.util.Objects;
 
 @SuppressWarnings("unused") public class Generic_A_Class extends A_Class implements IGenericNode
 { 
@@ -11,6 +12,7 @@ import org.spoofax.interpreter.core.Tools;
 
   public Generic_A_Class (INodeSource source, IStrategoTerm term) 
   { 
+    Objects.requireNonNull(term);
     this.setSourceInfo(source);
     this.aterm = term;
   }
@@ -38,7 +40,7 @@ import org.spoofax.interpreter.core.Tools;
       final INodeSource source = NodeSource.fromStrategoTerm(term);
       if(name.equals("Class") && term.getSubtermCount() == 4)
       { 
-        A_Class replacement = replace(new Class_4(source, Tools.asJavaString(term.getSubterm(0)), new Generic_A_Extends(NodeSource.fromStrategoTerm(term.getSubterm(1)), term.getSubterm(1)), new L_A_Field(NodeSource.fromStrategoTerm(term.getSubterm(2))).fromStrategoTerm(term.getSubterm(2)), new L_A_Method(NodeSource.fromStrategoTerm(term.getSubterm(3))).fromStrategoTerm(term.getSubterm(3))));
+        A_Class replacement = replace(new Class_4(source, TermUtils.stringFromTerm(term.getSubterm(0)), new Generic_A_Extends(NodeSource.fromStrategoTerm(term.getSubterm(1)), term.getSubterm(1)).specialize(1), new L_A_Field(NodeSource.fromStrategoTerm(term.getSubterm(2))).fromStrategoTerm(term.getSubterm(2)), new L_A_Method(NodeSource.fromStrategoTerm(term.getSubterm(3))).fromStrategoTerm(term.getSubterm(3))));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -46,7 +48,6 @@ import org.spoofax.interpreter.core.Tools;
         return replacement;
       }
     }
-    IGenericNode replacement = null;
     throw new RewritingException(aterm.toString());
   }
 

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_Expr.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_Expr.java
@@ -4,6 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 import org.spoofax.interpreter.terms.*;
 import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 import org.spoofax.interpreter.core.Tools;
+import java.util.Objects;
 
 @SuppressWarnings("unused") public class Generic_A_Expr extends A_Expr implements IGenericNode
 { 
@@ -11,6 +12,7 @@ import org.spoofax.interpreter.core.Tools;
 
   public Generic_A_Expr (INodeSource source, IStrategoTerm term) 
   { 
+    Objects.requireNonNull(term);
     this.setSourceInfo(source);
     this.aterm = term;
   }
@@ -38,7 +40,7 @@ import org.spoofax.interpreter.core.Tools;
       final INodeSource source = NodeSource.fromStrategoTerm(term);
       if(name.equals("Num") && term.getSubtermCount() == 1)
       { 
-        A_Expr replacement = replace(new Num_1(source, Tools.asJavaString(term.getSubterm(0))));
+        A_Expr replacement = replace(new Num_1(source, TermUtils.stringFromTerm(term.getSubterm(0))));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -47,7 +49,7 @@ import org.spoofax.interpreter.core.Tools;
       }
       if(name.equals("Min") && term.getSubtermCount() == 1)
       { 
-        A_Expr replacement = replace(new Min_1(source, new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0))));
+        A_Expr replacement = replace(new Min_1(source, new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)).specialize(1)));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -56,7 +58,7 @@ import org.spoofax.interpreter.core.Tools;
       }
       if(name.equals("Add") && term.getSubtermCount() == 2)
       { 
-        A_Expr replacement = replace(new Add_2(source, new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)), new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(1)), term.getSubterm(1))));
+        A_Expr replacement = replace(new Add_2(source, new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)).specialize(1), new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(1)), term.getSubterm(1)).specialize(1)));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -65,7 +67,7 @@ import org.spoofax.interpreter.core.Tools;
       }
       if(name.equals("Sub") && term.getSubtermCount() == 2)
       { 
-        A_Expr replacement = replace(new Sub_2(source, new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)), new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(1)), term.getSubterm(1))));
+        A_Expr replacement = replace(new Sub_2(source, new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)).specialize(1), new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(1)), term.getSubterm(1)).specialize(1)));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -74,7 +76,7 @@ import org.spoofax.interpreter.core.Tools;
       }
       if(name.equals("Mul") && term.getSubtermCount() == 2)
       { 
-        A_Expr replacement = replace(new Mul_2(source, new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)), new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(1)), term.getSubterm(1))));
+        A_Expr replacement = replace(new Mul_2(source, new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)).specialize(1), new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(1)), term.getSubterm(1)).specialize(1)));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -101,7 +103,7 @@ import org.spoofax.interpreter.core.Tools;
       }
       if(name.equals("Not") && term.getSubtermCount() == 1)
       { 
-        A_Expr replacement = replace(new Not_1(source, new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0))));
+        A_Expr replacement = replace(new Not_1(source, new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)).specialize(1)));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -110,7 +112,7 @@ import org.spoofax.interpreter.core.Tools;
       }
       if(name.equals("And") && term.getSubtermCount() == 2)
       { 
-        A_Expr replacement = replace(new And_2(source, new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)), new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(1)), term.getSubterm(1))));
+        A_Expr replacement = replace(new And_2(source, new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)).specialize(1), new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(1)), term.getSubterm(1)).specialize(1)));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -119,7 +121,7 @@ import org.spoofax.interpreter.core.Tools;
       }
       if(name.equals("Or") && term.getSubtermCount() == 2)
       { 
-        A_Expr replacement = replace(new Or_2(source, new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)), new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(1)), term.getSubterm(1))));
+        A_Expr replacement = replace(new Or_2(source, new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)).specialize(1), new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(1)), term.getSubterm(1)).specialize(1)));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -128,7 +130,7 @@ import org.spoofax.interpreter.core.Tools;
       }
       if(name.equals("Eq") && term.getSubtermCount() == 2)
       { 
-        A_Expr replacement = replace(new Eq_2(source, new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)), new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(1)), term.getSubterm(1))));
+        A_Expr replacement = replace(new Eq_2(source, new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)).specialize(1), new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(1)), term.getSubterm(1)).specialize(1)));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -137,7 +139,7 @@ import org.spoofax.interpreter.core.Tools;
       }
       if(name.equals("Neq") && term.getSubtermCount() == 2)
       { 
-        A_Expr replacement = replace(new Neq_2(source, new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)), new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(1)), term.getSubterm(1))));
+        A_Expr replacement = replace(new Neq_2(source, new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)).specialize(1), new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(1)), term.getSubterm(1)).specialize(1)));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -146,7 +148,7 @@ import org.spoofax.interpreter.core.Tools;
       }
       if(name.equals("Lt") && term.getSubtermCount() == 2)
       { 
-        A_Expr replacement = replace(new Lt_2(source, new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)), new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(1)), term.getSubterm(1))));
+        A_Expr replacement = replace(new Lt_2(source, new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)).specialize(1), new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(1)), term.getSubterm(1)).specialize(1)));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -155,7 +157,7 @@ import org.spoofax.interpreter.core.Tools;
       }
       if(name.equals("If") && term.getSubtermCount() == 3)
       { 
-        A_Expr replacement = replace(new If_3(source, new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)), new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(1)), term.getSubterm(1)), new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(2)), term.getSubterm(2))));
+        A_Expr replacement = replace(new If_3(source, new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)).specialize(1), new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(1)), term.getSubterm(1)).specialize(1), new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(2)), term.getSubterm(2)).specialize(1)));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -164,7 +166,7 @@ import org.spoofax.interpreter.core.Tools;
       }
       if(name.equals("Var") && term.getSubtermCount() == 1)
       { 
-        A_Expr replacement = replace(new Var_1(source, Tools.asJavaString(term.getSubterm(0))));
+        A_Expr replacement = replace(new Var_1(source, TermUtils.stringFromTerm(term.getSubterm(0))));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -173,7 +175,7 @@ import org.spoofax.interpreter.core.Tools;
       }
       if(name.equals("Let") && term.getSubtermCount() == 2)
       { 
-        A_Expr replacement = replace(new Let_2(source, new L_A_Bind(NodeSource.fromStrategoTerm(term.getSubterm(0))).fromStrategoTerm(term.getSubterm(0)), new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(1)), term.getSubterm(1))));
+        A_Expr replacement = replace(new Let_2(source, new L_A_Bind(NodeSource.fromStrategoTerm(term.getSubterm(0))).fromStrategoTerm(term.getSubterm(0)), new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(1)), term.getSubterm(1)).specialize(1)));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -182,7 +184,7 @@ import org.spoofax.interpreter.core.Tools;
       }
       if(name.equals("Get") && term.getSubtermCount() == 3)
       { 
-        A_Expr replacement = replace(new Get_3(source, new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)), new Generic_A_Type(NodeSource.fromStrategoTerm(term.getSubterm(1)), term.getSubterm(1)), Tools.asJavaString(term.getSubterm(2))));
+        A_Expr replacement = replace(new Get_3(source, new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)).specialize(1), new Generic_A_Type(NodeSource.fromStrategoTerm(term.getSubterm(1)), term.getSubterm(1)).specialize(1), TermUtils.stringFromTerm(term.getSubterm(2))));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -191,7 +193,7 @@ import org.spoofax.interpreter.core.Tools;
       }
       if(name.equals("Set") && term.getSubtermCount() == 4)
       { 
-        A_Expr replacement = replace(new Set_4(source, new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)), new Generic_A_Type(NodeSource.fromStrategoTerm(term.getSubterm(1)), term.getSubterm(1)), Tools.asJavaString(term.getSubterm(2)), new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(3)), term.getSubterm(3))));
+        A_Expr replacement = replace(new Set_4(source, new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)).specialize(1), new Generic_A_Type(NodeSource.fromStrategoTerm(term.getSubterm(1)), term.getSubterm(1)).specialize(1), TermUtils.stringFromTerm(term.getSubterm(2)), new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(3)), term.getSubterm(3)).specialize(1)));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -200,7 +202,7 @@ import org.spoofax.interpreter.core.Tools;
       }
       if(name.equals("Call") && term.getSubtermCount() == 3)
       { 
-        A_Expr replacement = replace(new Call_3(source, new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)), Tools.asJavaString(term.getSubterm(1)), new L_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(2))).fromStrategoTerm(term.getSubterm(2))));
+        A_Expr replacement = replace(new Call_3(source, new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)).specialize(1), TermUtils.stringFromTerm(term.getSubterm(1)), new L_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(2))).fromStrategoTerm(term.getSubterm(2))));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -209,7 +211,7 @@ import org.spoofax.interpreter.core.Tools;
       }
       if(name.equals("New") && term.getSubtermCount() == 1)
       { 
-        A_Expr replacement = replace(new New_1(source, Tools.asJavaString(term.getSubterm(0))));
+        A_Expr replacement = replace(new New_1(source, TermUtils.stringFromTerm(term.getSubterm(0))));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -227,7 +229,7 @@ import org.spoofax.interpreter.core.Tools;
       }
       if(name.equals("Null") && term.getSubtermCount() == 1)
       { 
-        A_Expr replacement = replace(new Null_1(source, Tools.asJavaString(term.getSubterm(0))));
+        A_Expr replacement = replace(new Null_1(source, TermUtils.stringFromTerm(term.getSubterm(0))));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -236,7 +238,16 @@ import org.spoofax.interpreter.core.Tools;
       }
       if(name.equals("Cast") && term.getSubtermCount() == 2)
       { 
-        A_Expr replacement = replace(new Cast_2(source, Tools.asJavaString(term.getSubterm(0)), new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(1)), term.getSubterm(1))));
+        A_Expr replacement = replace(new Cast_2(source, TermUtils.stringFromTerm(term.getSubterm(0)), new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(1)), term.getSubterm(1)).specialize(1)));
+        if(depth > 0)
+        { 
+          replacement.specializeChildren(depth - 1);
+        }
+        return replacement;
+      }
+      if(name.equals("block2expr") && term.getSubtermCount() == 1)
+      { 
+        A_Expr replacement = replace(new block2expr_1(source, new Generic_A_Block(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)).specialize(1)));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -244,17 +255,11 @@ import org.spoofax.interpreter.core.Tools;
         return replacement;
       }
     }
-    IGenericNode replacement = null;
     try
     { 
-      if(replacement != null)
-      { 
-        replacement.replace(this);
-      }
-      replacement = new Generic_A_Block(getSourceInfo(), aterm);
-      return replace(new block2expr_1(getSourceInfo(), (A_Block)replacement.specialize(1)));
+      return replace(new block2expr_1(getSourceInfo(), new Generic_A_Block(NodeSource.fromStrategoTerm(aterm), aterm).specialize(1)));
     }
-    catch(RewritingException o_111703)
+    catch(RewritingException h_353500)
     { }
     throw new RewritingException(aterm.toString());
   }
@@ -264,7 +269,7 @@ import org.spoofax.interpreter.core.Tools;
     return aterm;
   }
 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     return specialize(1).exec_default(_1, _2, _3, _4);
   }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_Extends.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_Extends.java
@@ -4,6 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 import org.spoofax.interpreter.terms.*;
 import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 import org.spoofax.interpreter.core.Tools;
+import java.util.Objects;
 
 @SuppressWarnings("unused") public class Generic_A_Extends extends A_Extends implements IGenericNode
 { 
@@ -11,6 +12,7 @@ import org.spoofax.interpreter.core.Tools;
 
   public Generic_A_Extends (INodeSource source, IStrategoTerm term) 
   { 
+    Objects.requireNonNull(term);
     this.setSourceInfo(source);
     this.aterm = term;
   }
@@ -47,7 +49,7 @@ import org.spoofax.interpreter.core.Tools;
       }
       if(name.equals("Extends") && term.getSubtermCount() == 1)
       { 
-        A_Extends replacement = replace(new Extends_1(source, Tools.asJavaString(term.getSubterm(0))));
+        A_Extends replacement = replace(new Extends_1(source, TermUtils.stringFromTerm(term.getSubterm(0))));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -55,7 +57,6 @@ import org.spoofax.interpreter.core.Tools;
         return replacement;
       }
     }
-    IGenericNode replacement = null;
     throw new RewritingException(aterm.toString());
   }
 

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_Field.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_Field.java
@@ -4,6 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 import org.spoofax.interpreter.terms.*;
 import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 import org.spoofax.interpreter.core.Tools;
+import java.util.Objects;
 
 @SuppressWarnings("unused") public class Generic_A_Field extends A_Field implements IGenericNode
 { 
@@ -11,6 +12,7 @@ import org.spoofax.interpreter.core.Tools;
 
   public Generic_A_Field (INodeSource source, IStrategoTerm term) 
   { 
+    Objects.requireNonNull(term);
     this.setSourceInfo(source);
     this.aterm = term;
   }
@@ -38,7 +40,7 @@ import org.spoofax.interpreter.core.Tools;
       final INodeSource source = NodeSource.fromStrategoTerm(term);
       if(name.equals("Field") && term.getSubtermCount() == 2)
       { 
-        A_Field replacement = replace(new Field_2(source, new Generic_A_Type(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)), Tools.asJavaString(term.getSubterm(1))));
+        A_Field replacement = replace(new Field_2(source, new Generic_A_Type(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)).specialize(1), TermUtils.stringFromTerm(term.getSubterm(1))));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -46,7 +48,6 @@ import org.spoofax.interpreter.core.Tools;
         return replacement;
       }
     }
-    IGenericNode replacement = null;
     throw new RewritingException(aterm.toString());
   }
 

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_FieldSet.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_FieldSet.java
@@ -4,6 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 import org.spoofax.interpreter.terms.*;
 import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 import org.spoofax.interpreter.core.Tools;
+import java.util.Objects;
 
 @SuppressWarnings("unused") public class Generic_A_FieldSet extends A_FieldSet implements IGenericNode
 { 
@@ -11,6 +12,7 @@ import org.spoofax.interpreter.core.Tools;
 
   public Generic_A_FieldSet (INodeSource source, IStrategoTerm term) 
   { 
+    Objects.requireNonNull(term);
     this.setSourceInfo(source);
     this.aterm = term;
   }
@@ -37,7 +39,6 @@ import org.spoofax.interpreter.core.Tools;
       final String name = term.getName();
       final INodeSource source = NodeSource.fromStrategoTerm(term);
     }
-    IGenericNode replacement = null;
     throw new RewritingException(aterm.toString());
   }
 

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_Method.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_Method.java
@@ -4,6 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 import org.spoofax.interpreter.terms.*;
 import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 import org.spoofax.interpreter.core.Tools;
+import java.util.Objects;
 
 @SuppressWarnings("unused") public class Generic_A_Method extends A_Method implements IGenericNode
 { 
@@ -11,6 +12,7 @@ import org.spoofax.interpreter.core.Tools;
 
   public Generic_A_Method (INodeSource source, IStrategoTerm term) 
   { 
+    Objects.requireNonNull(term);
     this.setSourceInfo(source);
     this.aterm = term;
   }
@@ -38,7 +40,7 @@ import org.spoofax.interpreter.core.Tools;
       final INodeSource source = NodeSource.fromStrategoTerm(term);
       if(name.equals("Method") && term.getSubtermCount() == 4)
       { 
-        A_Method replacement = replace(new Method_4(source, new Generic_A_Type(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)), Tools.asJavaString(term.getSubterm(1)), new L_A_Param(NodeSource.fromStrategoTerm(term.getSubterm(2))).fromStrategoTerm(term.getSubterm(2)), new Generic_A_Block(NodeSource.fromStrategoTerm(term.getSubterm(3)), term.getSubterm(3))));
+        A_Method replacement = replace(new Method_4(source, new Generic_A_Type(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)).specialize(1), TermUtils.stringFromTerm(term.getSubterm(1)), new L_A_Param(NodeSource.fromStrategoTerm(term.getSubterm(2))).fromStrategoTerm(term.getSubterm(2)), new Generic_A_Block(NodeSource.fromStrategoTerm(term.getSubterm(3)), term.getSubterm(3)).specialize(1)));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -46,7 +48,6 @@ import org.spoofax.interpreter.core.Tools;
         return replacement;
       }
     }
-    IGenericNode replacement = null;
     throw new RewritingException(aterm.toString());
   }
 

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_Obj.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_Obj.java
@@ -4,6 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 import org.spoofax.interpreter.terms.*;
 import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 import org.spoofax.interpreter.core.Tools;
+import java.util.Objects;
 
 @SuppressWarnings("unused") public class Generic_A_Obj extends A_Obj implements IGenericNode
 { 
@@ -11,6 +12,7 @@ import org.spoofax.interpreter.core.Tools;
 
   public Generic_A_Obj (INodeSource source, IStrategoTerm term) 
   { 
+    Objects.requireNonNull(term);
     this.setSourceInfo(source);
     this.aterm = term;
   }
@@ -38,7 +40,7 @@ import org.spoofax.interpreter.core.Tools;
       final INodeSource source = NodeSource.fromStrategoTerm(term);
       if(name.equals("ObjV") && term.getSubtermCount() == 4)
       { 
-        A_Obj replacement = replace(new ObjV_4(source, Tools.asJavaString(term.getSubterm(0)), new Generic_A_Super(NodeSource.fromStrategoTerm(term.getSubterm(1)), term.getSubterm(1)), AutoMapUtils.to_FM(term.getSubterm(2)), AutoMapUtils.to_MM(term.getSubterm(3))));
+        A_Obj replacement = replace(new ObjV_4(source, TermUtils.stringFromTerm(term.getSubterm(0)), new Generic_A_Super(NodeSource.fromStrategoTerm(term.getSubterm(1)), term.getSubterm(1)).specialize(1), AutoMapUtils.aterm2map_String_int(term.getSubterm(2)), AutoMapUtils.aterm2map_String_A_Method(term.getSubterm(3))));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -46,7 +48,6 @@ import org.spoofax.interpreter.core.Tools;
         return replacement;
       }
     }
-    IGenericNode replacement = null;
     throw new RewritingException(aterm.toString());
   }
 

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_Param.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_Param.java
@@ -4,6 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 import org.spoofax.interpreter.terms.*;
 import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 import org.spoofax.interpreter.core.Tools;
+import java.util.Objects;
 
 @SuppressWarnings("unused") public class Generic_A_Param extends A_Param implements IGenericNode
 { 
@@ -11,6 +12,7 @@ import org.spoofax.interpreter.core.Tools;
 
   public Generic_A_Param (INodeSource source, IStrategoTerm term) 
   { 
+    Objects.requireNonNull(term);
     this.setSourceInfo(source);
     this.aterm = term;
   }
@@ -38,7 +40,7 @@ import org.spoofax.interpreter.core.Tools;
       final INodeSource source = NodeSource.fromStrategoTerm(term);
       if(name.equals("Param") && term.getSubtermCount() == 2)
       { 
-        A_Param replacement = replace(new Param_2(source, new Generic_A_Type(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)), Tools.asJavaString(term.getSubterm(1))));
+        A_Param replacement = replace(new Param_2(source, new Generic_A_Type(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)).specialize(1), TermUtils.stringFromTerm(term.getSubterm(1))));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -46,7 +48,6 @@ import org.spoofax.interpreter.core.Tools;
         return replacement;
       }
     }
-    IGenericNode replacement = null;
     throw new RewritingException(aterm.toString());
   }
 

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_Program.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_Program.java
@@ -4,6 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 import org.spoofax.interpreter.terms.*;
 import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 import org.spoofax.interpreter.core.Tools;
+import java.util.Objects;
 
 @SuppressWarnings("unused") public class Generic_A_Program extends A_Program implements IGenericNode
 { 
@@ -11,6 +12,7 @@ import org.spoofax.interpreter.core.Tools;
 
   public Generic_A_Program (INodeSource source, IStrategoTerm term) 
   { 
+    Objects.requireNonNull(term);
     this.setSourceInfo(source);
     this.aterm = term;
   }
@@ -38,7 +40,7 @@ import org.spoofax.interpreter.core.Tools;
       final INodeSource source = NodeSource.fromStrategoTerm(term);
       if(name.equals("Program") && term.getSubtermCount() == 3)
       { 
-        A_Program replacement = replace(new Program_3(source, Tools.asJavaString(term.getSubterm(0)), new L_A_Class(NodeSource.fromStrategoTerm(term.getSubterm(1))).fromStrategoTerm(term.getSubterm(1)), new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(2)), term.getSubterm(2))));
+        A_Program replacement = replace(new Program_3(source, TermUtils.stringFromTerm(term.getSubterm(0)), new L_A_Class(NodeSource.fromStrategoTerm(term.getSubterm(1))).fromStrategoTerm(term.getSubterm(1)), new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(2)), term.getSubterm(2)).specialize(1)));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -46,7 +48,6 @@ import org.spoofax.interpreter.core.Tools;
         return replacement;
       }
     }
-    IGenericNode replacement = null;
     throw new RewritingException(aterm.toString());
   }
 
@@ -55,7 +56,7 @@ import org.spoofax.interpreter.core.Tools;
     return aterm;
   }
 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     return specialize(1).exec_default(_1, _2, _3, _4);
   }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_Program.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_Program.java
@@ -56,6 +56,11 @@ import java.util.Objects;
     return aterm;
   }
 
+  public R_init_V exec_init()
+  { 
+    return specialize(1).exec_init();
+  }
+
   public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     return specialize(1).exec_default(_1, _2, _3, _4);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_Seq.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_Seq.java
@@ -4,6 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 import org.spoofax.interpreter.terms.*;
 import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 import org.spoofax.interpreter.core.Tools;
+import java.util.Objects;
 
 @SuppressWarnings("unused") public class Generic_A_Seq extends A_Seq implements IGenericNode
 { 
@@ -11,6 +12,7 @@ import org.spoofax.interpreter.core.Tools;
 
   public Generic_A_Seq (INodeSource source, IStrategoTerm term) 
   { 
+    Objects.requireNonNull(term);
     this.setSourceInfo(source);
     this.aterm = term;
   }
@@ -45,18 +47,21 @@ import org.spoofax.interpreter.core.Tools;
         }
         return replacement;
       }
+      if(name.equals("expr2seq") && term.getSubtermCount() == 1)
+      { 
+        A_Seq replacement = replace(new expr2seq_1(source, new Generic_A_Expr(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)).specialize(1)));
+        if(depth > 0)
+        { 
+          replacement.specializeChildren(depth - 1);
+        }
+        return replacement;
+      }
     }
-    IGenericNode replacement = null;
     try
     { 
-      if(replacement != null)
-      { 
-        replacement.replace(this);
-      }
-      replacement = new Generic_A_Expr(getSourceInfo(), aterm);
-      return replace(new expr2seq_1(getSourceInfo(), (A_Expr)replacement.specialize(1)));
+      return replace(new expr2seq_1(getSourceInfo(), new Generic_A_Expr(NodeSource.fromStrategoTerm(aterm), aterm).specialize(1)));
     }
-    catch(RewritingException p_111703)
+    catch(RewritingException i_353500)
     { }
     throw new RewritingException(aterm.toString());
   }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_Super.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_Super.java
@@ -4,6 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 import org.spoofax.interpreter.terms.*;
 import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 import org.spoofax.interpreter.core.Tools;
+import java.util.Objects;
 
 @SuppressWarnings("unused") public class Generic_A_Super extends A_Super implements IGenericNode
 { 
@@ -11,6 +12,7 @@ import org.spoofax.interpreter.core.Tools;
 
   public Generic_A_Super (INodeSource source, IStrategoTerm term) 
   { 
+    Objects.requireNonNull(term);
     this.setSourceInfo(source);
     this.aterm = term;
   }
@@ -45,18 +47,21 @@ import org.spoofax.interpreter.core.Tools;
         }
         return replacement;
       }
+      if(name.equals("Super") && term.getSubtermCount() == 1)
+      { 
+        A_Super replacement = replace(new Super_1(source, new Generic_A_Obj(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)).specialize(1)));
+        if(depth > 0)
+        { 
+          replacement.specializeChildren(depth - 1);
+        }
+        return replacement;
+      }
     }
-    IGenericNode replacement = null;
     try
     { 
-      if(replacement != null)
-      { 
-        replacement.replace(this);
-      }
-      replacement = new Generic_A_Obj(getSourceInfo(), aterm);
-      return replace(new Super_1(getSourceInfo(), (A_Obj)replacement.specialize(1)));
+      return replace(new Super_1(getSourceInfo(), new Generic_A_Obj(NodeSource.fromStrategoTerm(aterm), aterm).specialize(1)));
     }
-    catch(RewritingException n_111703)
+    catch(RewritingException g_353500)
     { }
     throw new RewritingException(aterm.toString());
   }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_This.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_This.java
@@ -4,6 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 import org.spoofax.interpreter.terms.*;
 import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 import org.spoofax.interpreter.core.Tools;
+import java.util.Objects;
 
 @SuppressWarnings("unused") public class Generic_A_This extends A_This implements IGenericNode
 { 
@@ -11,6 +12,7 @@ import org.spoofax.interpreter.core.Tools;
 
   public Generic_A_This (INodeSource source, IStrategoTerm term) 
   { 
+    Objects.requireNonNull(term);
     this.setSourceInfo(source);
     this.aterm = term;
   }
@@ -36,18 +38,21 @@ import org.spoofax.interpreter.core.Tools;
       final IStrategoAppl term = (IStrategoAppl)aterm;
       final String name = term.getName();
       final INodeSource source = NodeSource.fromStrategoTerm(term);
+      if(name.equals("T") && term.getSubtermCount() == 1)
+      { 
+        A_This replacement = replace(new T_1(source, new Generic_A_Obj(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)).specialize(1)));
+        if(depth > 0)
+        { 
+          replacement.specializeChildren(depth - 1);
+        }
+        return replacement;
+      }
     }
-    IGenericNode replacement = null;
     try
     { 
-      if(replacement != null)
-      { 
-        replacement.replace(this);
-      }
-      replacement = new Generic_A_Obj(getSourceInfo(), aterm);
-      return replace(new T_1(getSourceInfo(), (A_Obj)replacement.specialize(1)));
+      return replace(new T_1(getSourceInfo(), new Generic_A_Obj(NodeSource.fromStrategoTerm(aterm), aterm).specialize(1)));
     }
-    catch(RewritingException m_111703)
+    catch(RewritingException f_353500)
     { }
     throw new RewritingException(aterm.toString());
   }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_Type.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_Type.java
@@ -4,6 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 import org.spoofax.interpreter.terms.*;
 import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 import org.spoofax.interpreter.core.Tools;
+import java.util.Objects;
 
 @SuppressWarnings("unused") public class Generic_A_Type extends A_Type implements IGenericNode
 { 
@@ -11,6 +12,7 @@ import org.spoofax.interpreter.core.Tools;
 
   public Generic_A_Type (INodeSource source, IStrategoTerm term) 
   { 
+    Objects.requireNonNull(term);
     this.setSourceInfo(source);
     this.aterm = term;
   }
@@ -65,7 +67,7 @@ import org.spoofax.interpreter.core.Tools;
       }
       if(name.equals("ClassT") && term.getSubtermCount() == 1)
       { 
-        A_Type replacement = replace(new ClassT_1(source, Tools.asJavaString(term.getSubterm(0))));
+        A_Type replacement = replace(new ClassT_1(source, TermUtils.stringFromTerm(term.getSubterm(0))));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -73,7 +75,6 @@ import org.spoofax.interpreter.core.Tools;
         return replacement;
       }
     }
-    IGenericNode replacement = null;
     throw new RewritingException(aterm.toString());
   }
 

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_Unit.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_Unit.java
@@ -4,6 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 import org.spoofax.interpreter.terms.*;
 import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 import org.spoofax.interpreter.core.Tools;
+import java.util.Objects;
 
 @SuppressWarnings("unused") public class Generic_A_Unit extends A_Unit implements IGenericNode
 { 
@@ -11,6 +12,7 @@ import org.spoofax.interpreter.core.Tools;
 
   public Generic_A_Unit (INodeSource source, IStrategoTerm term) 
   { 
+    Objects.requireNonNull(term);
     this.setSourceInfo(source);
     this.aterm = term;
   }
@@ -46,7 +48,6 @@ import org.spoofax.interpreter.core.Tools;
         return replacement;
       }
     }
-    IGenericNode replacement = null;
     throw new RewritingException(aterm.toString());
   }
 

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_V.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_V.java
@@ -4,6 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 import org.spoofax.interpreter.terms.*;
 import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 import org.spoofax.interpreter.core.Tools;
+import java.util.Objects;
 
 @SuppressWarnings("unused") public class Generic_A_V extends A_V implements IGenericNode
 { 
@@ -11,6 +12,7 @@ import org.spoofax.interpreter.core.Tools;
 
   public Generic_A_V (INodeSource source, IStrategoTerm term) 
   { 
+    Objects.requireNonNull(term);
     this.setSourceInfo(source);
     this.aterm = term;
   }
@@ -38,7 +40,7 @@ import org.spoofax.interpreter.core.Tools;
       final INodeSource source = NodeSource.fromStrategoTerm(term);
       if(name.equals("NumV") && term.getSubtermCount() == 1)
       { 
-        A_V replacement = replace(new NumV_1(source, Tools.asJavaInt(term.getSubterm(0))));
+        A_V replacement = replace(new NumV_1(source, TermUtils.intFromTerm(term.getSubterm(0))));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -72,29 +74,36 @@ import org.spoofax.interpreter.core.Tools;
         }
         return replacement;
       }
+      if(name.equals("o2v") && term.getSubtermCount() == 1)
+      { 
+        A_V replacement = replace(new o2v_1(source, new Generic_A_Obj(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)).specialize(1)));
+        if(depth > 0)
+        { 
+          replacement.specializeChildren(depth - 1);
+        }
+        return replacement;
+      }
+      if(name.equals("u2v") && term.getSubtermCount() == 1)
+      { 
+        A_V replacement = replace(new u2v_1(source, new Generic_A_Unit(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)).specialize(1)));
+        if(depth > 0)
+        { 
+          replacement.specializeChildren(depth - 1);
+        }
+        return replacement;
+      }
     }
-    IGenericNode replacement = null;
     try
     { 
-      if(replacement != null)
-      { 
-        replacement.replace(this);
-      }
-      replacement = new Generic_A_Obj(getSourceInfo(), aterm);
-      return replace(new o2v_1(getSourceInfo(), (A_Obj)replacement.specialize(1)));
+      return replace(new o2v_1(getSourceInfo(), new Generic_A_Obj(NodeSource.fromStrategoTerm(aterm), aterm).specialize(1)));
     }
-    catch(RewritingException r_111703)
+    catch(RewritingException k_353500)
     { 
       try
       { 
-        if(replacement != null)
-        { 
-          replacement.replace(this);
-        }
-        replacement = new Generic_A_Unit(getSourceInfo(), aterm);
-        return replace(new u2v_1(getSourceInfo(), (A_Unit)replacement.specialize(1)));
+        return replace(new u2v_1(getSourceInfo(), new Generic_A_Unit(NodeSource.fromStrategoTerm(aterm), aterm).specialize(1)));
       }
-      catch(RewritingException q_111703)
+      catch(RewritingException j_353500)
       { }
     }
     throw new RewritingException(aterm.toString());

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_allocate__Arrow.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_allocate__Arrow.java
@@ -4,6 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 import org.spoofax.interpreter.terms.*;
 import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 import org.spoofax.interpreter.core.Tools;
+import java.util.Objects;
 
 @SuppressWarnings("unused") public class Generic_A_allocate__Arrow extends A_allocate__Arrow implements IGenericNode
 { 
@@ -11,6 +12,7 @@ import org.spoofax.interpreter.core.Tools;
 
   public Generic_A_allocate__Arrow (INodeSource source, IStrategoTerm term) 
   { 
+    Objects.requireNonNull(term);
     this.setSourceInfo(source);
     this.aterm = term;
   }
@@ -38,7 +40,7 @@ import org.spoofax.interpreter.core.Tools;
       final INodeSource source = NodeSource.fromStrategoTerm(term);
       if(name.equals("allocate") && term.getSubtermCount() == 1)
       { 
-        A_allocate__Arrow replacement = replace(new allocate_1(source, new Generic_A_V(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0))));
+        A_allocate__Arrow replacement = replace(new allocate_1(source, new Generic_A_V(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)).specialize(1)));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -46,7 +48,6 @@ import org.spoofax.interpreter.core.Tools;
         return replacement;
       }
     }
-    IGenericNode replacement = null;
     throw new RewritingException(aterm.toString());
   }
 
@@ -55,7 +56,7 @@ import org.spoofax.interpreter.core.Tools;
     return aterm;
   }
 
-  public R_default_Int exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_Int exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     return specialize(1).exec_default(_1, _2, _3, _4);
   }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_bindVar__Arrow.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_bindVar__Arrow.java
@@ -4,6 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 import org.spoofax.interpreter.terms.*;
 import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 import org.spoofax.interpreter.core.Tools;
+import java.util.Objects;
 
 @SuppressWarnings("unused") public class Generic_A_bindVar__Arrow extends A_bindVar__Arrow implements IGenericNode
 { 
@@ -11,6 +12,7 @@ import org.spoofax.interpreter.core.Tools;
 
   public Generic_A_bindVar__Arrow (INodeSource source, IStrategoTerm term) 
   { 
+    Objects.requireNonNull(term);
     this.setSourceInfo(source);
     this.aterm = term;
   }
@@ -38,7 +40,7 @@ import org.spoofax.interpreter.core.Tools;
       final INodeSource source = NodeSource.fromStrategoTerm(term);
       if(name.equals("bindVar") && term.getSubtermCount() == 2)
       { 
-        A_bindVar__Arrow replacement = replace(new bindVar_2(source, Tools.asJavaString(term.getSubterm(0)), new Generic_A_V(NodeSource.fromStrategoTerm(term.getSubterm(1)), term.getSubterm(1))));
+        A_bindVar__Arrow replacement = replace(new bindVar_2(source, TermUtils.stringFromTerm(term.getSubterm(0)), new Generic_A_V(NodeSource.fromStrategoTerm(term.getSubterm(1)), term.getSubterm(1)).specialize(1)));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -46,7 +48,6 @@ import org.spoofax.interpreter.core.Tools;
         return replacement;
       }
     }
-    IGenericNode replacement = null;
     throw new RewritingException(aterm.toString());
   }
 
@@ -55,7 +56,7 @@ import org.spoofax.interpreter.core.Tools;
     return aterm;
   }
 
-  public R_default_Env exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_Map_String_V_ exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     return specialize(1).exec_default(_1, _2, _3, _4);
   }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_bindVars__Arrow.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_bindVars__Arrow.java
@@ -4,6 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 import org.spoofax.interpreter.terms.*;
 import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 import org.spoofax.interpreter.core.Tools;
+import java.util.Objects;
 
 @SuppressWarnings("unused") public class Generic_A_bindVars__Arrow extends A_bindVars__Arrow implements IGenericNode
 { 
@@ -11,6 +12,7 @@ import org.spoofax.interpreter.core.Tools;
 
   public Generic_A_bindVars__Arrow (INodeSource source, IStrategoTerm term) 
   { 
+    Objects.requireNonNull(term);
     this.setSourceInfo(source);
     this.aterm = term;
   }
@@ -46,7 +48,6 @@ import org.spoofax.interpreter.core.Tools;
         return replacement;
       }
     }
-    IGenericNode replacement = null;
     throw new RewritingException(aterm.toString());
   }
 
@@ -55,7 +56,7 @@ import org.spoofax.interpreter.core.Tools;
     return aterm;
   }
 
-  public R_default_Env exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_Map_String_V_ exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     return specialize(1).exec_default(_1, _2, _3, _4);
   }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_defaultValue__Arrow.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_defaultValue__Arrow.java
@@ -4,6 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 import org.spoofax.interpreter.terms.*;
 import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 import org.spoofax.interpreter.core.Tools;
+import java.util.Objects;
 
 @SuppressWarnings("unused") public class Generic_A_defaultValue__Arrow extends A_defaultValue__Arrow implements IGenericNode
 { 
@@ -11,6 +12,7 @@ import org.spoofax.interpreter.core.Tools;
 
   public Generic_A_defaultValue__Arrow (INodeSource source, IStrategoTerm term) 
   { 
+    Objects.requireNonNull(term);
     this.setSourceInfo(source);
     this.aterm = term;
   }
@@ -38,7 +40,7 @@ import org.spoofax.interpreter.core.Tools;
       final INodeSource source = NodeSource.fromStrategoTerm(term);
       if(name.equals("defaultValue") && term.getSubtermCount() == 1)
       { 
-        A_defaultValue__Arrow replacement = replace(new defaultValue_1(source, new Generic_A_Type(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0))));
+        A_defaultValue__Arrow replacement = replace(new defaultValue_1(source, new Generic_A_Type(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)).specialize(1)));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -46,7 +48,6 @@ import org.spoofax.interpreter.core.Tools;
         return replacement;
       }
     }
-    IGenericNode replacement = null;
     throw new RewritingException(aterm.toString());
   }
 
@@ -55,7 +56,7 @@ import org.spoofax.interpreter.core.Tools;
     return aterm;
   }
 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     return specialize(1).exec_default(_1, _2, _3, _4);
   }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_initClasses__Arrow.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_initClasses__Arrow.java
@@ -4,6 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 import org.spoofax.interpreter.terms.*;
 import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 import org.spoofax.interpreter.core.Tools;
+import java.util.Objects;
 
 @SuppressWarnings("unused") public class Generic_A_initClasses__Arrow extends A_initClasses__Arrow implements IGenericNode
 { 
@@ -11,6 +12,7 @@ import org.spoofax.interpreter.core.Tools;
 
   public Generic_A_initClasses__Arrow (INodeSource source, IStrategoTerm term) 
   { 
+    Objects.requireNonNull(term);
     this.setSourceInfo(source);
     this.aterm = term;
   }
@@ -46,7 +48,6 @@ import org.spoofax.interpreter.core.Tools;
         return replacement;
       }
     }
-    IGenericNode replacement = null;
     throw new RewritingException(aterm.toString());
   }
 
@@ -55,7 +56,7 @@ import org.spoofax.interpreter.core.Tools;
     return aterm;
   }
 
-  public R_default_C exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_Map_String_Class_ exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     return specialize(1).exec_default(_1, _2, _3, _4);
   }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_initFields__Arrow.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_initFields__Arrow.java
@@ -4,6 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 import org.spoofax.interpreter.terms.*;
 import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 import org.spoofax.interpreter.core.Tools;
+import java.util.Objects;
 
 @SuppressWarnings("unused") public class Generic_A_initFields__Arrow extends A_initFields__Arrow implements IGenericNode
 { 
@@ -11,6 +12,7 @@ import org.spoofax.interpreter.core.Tools;
 
   public Generic_A_initFields__Arrow (INodeSource source, IStrategoTerm term) 
   { 
+    Objects.requireNonNull(term);
     this.setSourceInfo(source);
     this.aterm = term;
   }
@@ -46,7 +48,6 @@ import org.spoofax.interpreter.core.Tools;
         return replacement;
       }
     }
-    IGenericNode replacement = null;
     throw new RewritingException(aterm.toString());
   }
 
@@ -55,7 +56,7 @@ import org.spoofax.interpreter.core.Tools;
     return aterm;
   }
 
-  public R_default_FM exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_Map_String_Int_ exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     return specialize(1).exec_default(_1, _2, _3, _4);
   }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_initMethods__Arrow.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_initMethods__Arrow.java
@@ -4,6 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 import org.spoofax.interpreter.terms.*;
 import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 import org.spoofax.interpreter.core.Tools;
+import java.util.Objects;
 
 @SuppressWarnings("unused") public class Generic_A_initMethods__Arrow extends A_initMethods__Arrow implements IGenericNode
 { 
@@ -11,6 +12,7 @@ import org.spoofax.interpreter.core.Tools;
 
   public Generic_A_initMethods__Arrow (INodeSource source, IStrategoTerm term) 
   { 
+    Objects.requireNonNull(term);
     this.setSourceInfo(source);
     this.aterm = term;
   }
@@ -46,7 +48,6 @@ import org.spoofax.interpreter.core.Tools;
         return replacement;
       }
     }
-    IGenericNode replacement = null;
     throw new RewritingException(aterm.toString());
   }
 
@@ -55,7 +56,7 @@ import org.spoofax.interpreter.core.Tools;
     return aterm;
   }
 
-  public R_default_MM exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_Map_String_Method_ exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     return specialize(1).exec_default(_1, _2, _3, _4);
   }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_initObject__Arrow.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_initObject__Arrow.java
@@ -4,6 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 import org.spoofax.interpreter.terms.*;
 import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 import org.spoofax.interpreter.core.Tools;
+import java.util.Objects;
 
 @SuppressWarnings("unused") public class Generic_A_initObject__Arrow extends A_initObject__Arrow implements IGenericNode
 { 
@@ -11,6 +12,7 @@ import org.spoofax.interpreter.core.Tools;
 
   public Generic_A_initObject__Arrow (INodeSource source, IStrategoTerm term) 
   { 
+    Objects.requireNonNull(term);
     this.setSourceInfo(source);
     this.aterm = term;
   }
@@ -38,7 +40,7 @@ import org.spoofax.interpreter.core.Tools;
       final INodeSource source = NodeSource.fromStrategoTerm(term);
       if(name.equals("initObject") && term.getSubtermCount() == 1)
       { 
-        A_initObject__Arrow replacement = replace(new initObject_1(source, new Generic_A_Class(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0))));
+        A_initObject__Arrow replacement = replace(new initObject_1(source, new Generic_A_Class(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)).specialize(1)));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -46,7 +48,6 @@ import org.spoofax.interpreter.core.Tools;
         return replacement;
       }
     }
-    IGenericNode replacement = null;
     throw new RewritingException(aterm.toString());
   }
 
@@ -55,7 +56,7 @@ import org.spoofax.interpreter.core.Tools;
     return aterm;
   }
 
-  public R_default_Obj exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_Obj exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     return specialize(1).exec_default(_1, _2, _3, _4);
   }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_initSuper__Arrow.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_initSuper__Arrow.java
@@ -4,6 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 import org.spoofax.interpreter.terms.*;
 import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 import org.spoofax.interpreter.core.Tools;
+import java.util.Objects;
 
 @SuppressWarnings("unused") public class Generic_A_initSuper__Arrow extends A_initSuper__Arrow implements IGenericNode
 { 
@@ -11,6 +12,7 @@ import org.spoofax.interpreter.core.Tools;
 
   public Generic_A_initSuper__Arrow (INodeSource source, IStrategoTerm term) 
   { 
+    Objects.requireNonNull(term);
     this.setSourceInfo(source);
     this.aterm = term;
   }
@@ -38,7 +40,7 @@ import org.spoofax.interpreter.core.Tools;
       final INodeSource source = NodeSource.fromStrategoTerm(term);
       if(name.equals("initSuper") && term.getSubtermCount() == 1)
       { 
-        A_initSuper__Arrow replacement = replace(new initSuper_1(source, new Generic_A_Extends(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0))));
+        A_initSuper__Arrow replacement = replace(new initSuper_1(source, new Generic_A_Extends(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)).specialize(1)));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -46,7 +48,6 @@ import org.spoofax.interpreter.core.Tools;
         return replacement;
       }
     }
-    IGenericNode replacement = null;
     throw new RewritingException(aterm.toString());
   }
 
@@ -55,7 +56,7 @@ import org.spoofax.interpreter.core.Tools;
     return aterm;
   }
 
-  public R_default_Super exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_Super exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     return specialize(1).exec_default(_1, _2, _3, _4);
   }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_loadClass__Arrow.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_loadClass__Arrow.java
@@ -4,6 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 import org.spoofax.interpreter.terms.*;
 import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 import org.spoofax.interpreter.core.Tools;
+import java.util.Objects;
 
 @SuppressWarnings("unused") public class Generic_A_loadClass__Arrow extends A_loadClass__Arrow implements IGenericNode
 { 
@@ -11,6 +12,7 @@ import org.spoofax.interpreter.core.Tools;
 
   public Generic_A_loadClass__Arrow (INodeSource source, IStrategoTerm term) 
   { 
+    Objects.requireNonNull(term);
     this.setSourceInfo(source);
     this.aterm = term;
   }
@@ -38,7 +40,7 @@ import org.spoofax.interpreter.core.Tools;
       final INodeSource source = NodeSource.fromStrategoTerm(term);
       if(name.equals("loadClass") && term.getSubtermCount() == 1)
       { 
-        A_loadClass__Arrow replacement = replace(new loadClass_1(source, Tools.asJavaString(term.getSubterm(0))));
+        A_loadClass__Arrow replacement = replace(new loadClass_1(source, TermUtils.stringFromTerm(term.getSubterm(0))));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -46,7 +48,6 @@ import org.spoofax.interpreter.core.Tools;
         return replacement;
       }
     }
-    IGenericNode replacement = null;
     throw new RewritingException(aterm.toString());
   }
 
@@ -55,7 +56,7 @@ import org.spoofax.interpreter.core.Tools;
     return aterm;
   }
 
-  public R_default_Class exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_Class exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     return specialize(1).exec_default(_1, _2, _3, _4);
   }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_lookupField__Arrow.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_lookupField__Arrow.java
@@ -4,6 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 import org.spoofax.interpreter.terms.*;
 import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 import org.spoofax.interpreter.core.Tools;
+import java.util.Objects;
 
 @SuppressWarnings("unused") public class Generic_A_lookupField__Arrow extends A_lookupField__Arrow implements IGenericNode
 { 
@@ -11,6 +12,7 @@ import org.spoofax.interpreter.core.Tools;
 
   public Generic_A_lookupField__Arrow (INodeSource source, IStrategoTerm term) 
   { 
+    Objects.requireNonNull(term);
     this.setSourceInfo(source);
     this.aterm = term;
   }
@@ -38,7 +40,7 @@ import org.spoofax.interpreter.core.Tools;
       final INodeSource source = NodeSource.fromStrategoTerm(term);
       if(name.equals("lookupField") && term.getSubtermCount() == 3)
       { 
-        A_lookupField__Arrow replacement = replace(new lookupField_3(source, new Generic_A_Obj(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)), Tools.asJavaString(term.getSubterm(1)), Tools.asJavaString(term.getSubterm(2))));
+        A_lookupField__Arrow replacement = replace(new lookupField_3(source, new Generic_A_Obj(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)).specialize(1), TermUtils.stringFromTerm(term.getSubterm(1)), TermUtils.stringFromTerm(term.getSubterm(2))));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -46,7 +48,6 @@ import org.spoofax.interpreter.core.Tools;
         return replacement;
       }
     }
-    IGenericNode replacement = null;
     throw new RewritingException(aterm.toString());
   }
 
@@ -55,7 +56,7 @@ import org.spoofax.interpreter.core.Tools;
     return aterm;
   }
 
-  public R_default_Int exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_Int exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     return specialize(1).exec_default(_1, _2, _3, _4);
   }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_lookupMethod__Arrow.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_lookupMethod__Arrow.java
@@ -4,6 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 import org.spoofax.interpreter.terms.*;
 import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 import org.spoofax.interpreter.core.Tools;
+import java.util.Objects;
 
 @SuppressWarnings("unused") public class Generic_A_lookupMethod__Arrow extends A_lookupMethod__Arrow implements IGenericNode
 { 
@@ -11,6 +12,7 @@ import org.spoofax.interpreter.core.Tools;
 
   public Generic_A_lookupMethod__Arrow (INodeSource source, IStrategoTerm term) 
   { 
+    Objects.requireNonNull(term);
     this.setSourceInfo(source);
     this.aterm = term;
   }
@@ -38,7 +40,7 @@ import org.spoofax.interpreter.core.Tools;
       final INodeSource source = NodeSource.fromStrategoTerm(term);
       if(name.equals("lookupMethod") && term.getSubtermCount() == 2)
       { 
-        A_lookupMethod__Arrow replacement = replace(new lookupMethod_2(source, new Generic_A_Obj(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)), Tools.asJavaString(term.getSubterm(1))));
+        A_lookupMethod__Arrow replacement = replace(new lookupMethod_2(source, new Generic_A_Obj(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)).specialize(1), TermUtils.stringFromTerm(term.getSubterm(1))));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -46,7 +48,6 @@ import org.spoofax.interpreter.core.Tools;
         return replacement;
       }
     }
-    IGenericNode replacement = null;
     throw new RewritingException(aterm.toString());
   }
 
@@ -55,7 +56,7 @@ import org.spoofax.interpreter.core.Tools;
     return aterm;
   }
 
-  public R_default_Method exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_Method exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     return specialize(1).exec_default(_1, _2, _3, _4);
   }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_readField__Arrow.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_readField__Arrow.java
@@ -4,6 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 import org.spoofax.interpreter.terms.*;
 import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 import org.spoofax.interpreter.core.Tools;
+import java.util.Objects;
 
 @SuppressWarnings("unused") public class Generic_A_readField__Arrow extends A_readField__Arrow implements IGenericNode
 { 
@@ -11,6 +12,7 @@ import org.spoofax.interpreter.core.Tools;
 
   public Generic_A_readField__Arrow (INodeSource source, IStrategoTerm term) 
   { 
+    Objects.requireNonNull(term);
     this.setSourceInfo(source);
     this.aterm = term;
   }
@@ -38,7 +40,7 @@ import org.spoofax.interpreter.core.Tools;
       final INodeSource source = NodeSource.fromStrategoTerm(term);
       if(name.equals("readField") && term.getSubtermCount() == 3)
       { 
-        A_readField__Arrow replacement = replace(new readField_3(source, new Generic_A_Obj(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)), Tools.asJavaString(term.getSubterm(1)), Tools.asJavaString(term.getSubterm(2))));
+        A_readField__Arrow replacement = replace(new readField_3(source, new Generic_A_Obj(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)).specialize(1), TermUtils.stringFromTerm(term.getSubterm(1)), TermUtils.stringFromTerm(term.getSubterm(2))));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -46,7 +48,6 @@ import org.spoofax.interpreter.core.Tools;
         return replacement;
       }
     }
-    IGenericNode replacement = null;
     throw new RewritingException(aterm.toString());
   }
 
@@ -55,7 +56,7 @@ import org.spoofax.interpreter.core.Tools;
     return aterm;
   }
 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     return specialize(1).exec_default(_1, _2, _3, _4);
   }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_readVar__Arrow.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_readVar__Arrow.java
@@ -4,6 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 import org.spoofax.interpreter.terms.*;
 import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 import org.spoofax.interpreter.core.Tools;
+import java.util.Objects;
 
 @SuppressWarnings("unused") public class Generic_A_readVar__Arrow extends A_readVar__Arrow implements IGenericNode
 { 
@@ -11,6 +12,7 @@ import org.spoofax.interpreter.core.Tools;
 
   public Generic_A_readVar__Arrow (INodeSource source, IStrategoTerm term) 
   { 
+    Objects.requireNonNull(term);
     this.setSourceInfo(source);
     this.aterm = term;
   }
@@ -38,7 +40,7 @@ import org.spoofax.interpreter.core.Tools;
       final INodeSource source = NodeSource.fromStrategoTerm(term);
       if(name.equals("readVar") && term.getSubtermCount() == 1)
       { 
-        A_readVar__Arrow replacement = replace(new readVar_1(source, Tools.asJavaString(term.getSubterm(0))));
+        A_readVar__Arrow replacement = replace(new readVar_1(source, TermUtils.stringFromTerm(term.getSubterm(0))));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -46,7 +48,6 @@ import org.spoofax.interpreter.core.Tools;
         return replacement;
       }
     }
-    IGenericNode replacement = null;
     throw new RewritingException(aterm.toString());
   }
 
@@ -55,7 +56,7 @@ import org.spoofax.interpreter.core.Tools;
     return aterm;
   }
 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     return specialize(1).exec_default(_1, _2, _3, _4);
   }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_read__Arrow.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_read__Arrow.java
@@ -4,6 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 import org.spoofax.interpreter.terms.*;
 import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 import org.spoofax.interpreter.core.Tools;
+import java.util.Objects;
 
 @SuppressWarnings("unused") public class Generic_A_read__Arrow extends A_read__Arrow implements IGenericNode
 { 
@@ -11,6 +12,7 @@ import org.spoofax.interpreter.core.Tools;
 
   public Generic_A_read__Arrow (INodeSource source, IStrategoTerm term) 
   { 
+    Objects.requireNonNull(term);
     this.setSourceInfo(source);
     this.aterm = term;
   }
@@ -38,7 +40,7 @@ import org.spoofax.interpreter.core.Tools;
       final INodeSource source = NodeSource.fromStrategoTerm(term);
       if(name.equals("read") && term.getSubtermCount() == 1)
       { 
-        A_read__Arrow replacement = replace(new read_1(source, Tools.asJavaInt(term.getSubterm(0))));
+        A_read__Arrow replacement = replace(new read_1(source, TermUtils.intFromTerm(term.getSubterm(0))));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -46,7 +48,6 @@ import org.spoofax.interpreter.core.Tools;
         return replacement;
       }
     }
-    IGenericNode replacement = null;
     throw new RewritingException(aterm.toString());
   }
 
@@ -55,7 +56,7 @@ import org.spoofax.interpreter.core.Tools;
     return aterm;
   }
 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     return specialize(1).exec_default(_1, _2, _3, _4);
   }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_writeField__Arrow.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_writeField__Arrow.java
@@ -4,6 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 import org.spoofax.interpreter.terms.*;
 import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 import org.spoofax.interpreter.core.Tools;
+import java.util.Objects;
 
 @SuppressWarnings("unused") public class Generic_A_writeField__Arrow extends A_writeField__Arrow implements IGenericNode
 { 
@@ -11,6 +12,7 @@ import org.spoofax.interpreter.core.Tools;
 
   public Generic_A_writeField__Arrow (INodeSource source, IStrategoTerm term) 
   { 
+    Objects.requireNonNull(term);
     this.setSourceInfo(source);
     this.aterm = term;
   }
@@ -38,7 +40,7 @@ import org.spoofax.interpreter.core.Tools;
       final INodeSource source = NodeSource.fromStrategoTerm(term);
       if(name.equals("writeField") && term.getSubtermCount() == 4)
       { 
-        A_writeField__Arrow replacement = replace(new writeField_4(source, new Generic_A_Obj(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)), Tools.asJavaString(term.getSubterm(1)), Tools.asJavaString(term.getSubterm(2)), new Generic_A_V(NodeSource.fromStrategoTerm(term.getSubterm(3)), term.getSubterm(3))));
+        A_writeField__Arrow replacement = replace(new writeField_4(source, new Generic_A_Obj(NodeSource.fromStrategoTerm(term.getSubterm(0)), term.getSubterm(0)).specialize(1), TermUtils.stringFromTerm(term.getSubterm(1)), TermUtils.stringFromTerm(term.getSubterm(2)), new Generic_A_V(NodeSource.fromStrategoTerm(term.getSubterm(3)), term.getSubterm(3)).specialize(1)));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -46,7 +48,6 @@ import org.spoofax.interpreter.core.Tools;
         return replacement;
       }
     }
-    IGenericNode replacement = null;
     throw new RewritingException(aterm.toString());
   }
 
@@ -55,7 +56,7 @@ import org.spoofax.interpreter.core.Tools;
     return aterm;
   }
 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     return specialize(1).exec_default(_1, _2, _3, _4);
   }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_write__Arrow.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Generic_A_write__Arrow.java
@@ -4,6 +4,7 @@ import org.metaborg.meta.interpreter.framework.*;
 import org.spoofax.interpreter.terms.*;
 import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 import org.spoofax.interpreter.core.Tools;
+import java.util.Objects;
 
 @SuppressWarnings("unused") public class Generic_A_write__Arrow extends A_write__Arrow implements IGenericNode
 { 
@@ -11,6 +12,7 @@ import org.spoofax.interpreter.core.Tools;
 
   public Generic_A_write__Arrow (INodeSource source, IStrategoTerm term) 
   { 
+    Objects.requireNonNull(term);
     this.setSourceInfo(source);
     this.aterm = term;
   }
@@ -38,7 +40,7 @@ import org.spoofax.interpreter.core.Tools;
       final INodeSource source = NodeSource.fromStrategoTerm(term);
       if(name.equals("write") && term.getSubtermCount() == 2)
       { 
-        A_write__Arrow replacement = replace(new write_2(source, Tools.asJavaInt(term.getSubterm(0)), new Generic_A_V(NodeSource.fromStrategoTerm(term.getSubterm(1)), term.getSubterm(1))));
+        A_write__Arrow replacement = replace(new write_2(source, TermUtils.intFromTerm(term.getSubterm(0)), new Generic_A_V(NodeSource.fromStrategoTerm(term.getSubterm(1)), term.getSubterm(1)).specialize(1)));
         if(depth > 0)
         { 
           replacement.specializeChildren(depth - 1);
@@ -46,7 +48,6 @@ import org.spoofax.interpreter.core.Tools;
         return replacement;
       }
     }
-    IGenericNode replacement = null;
     throw new RewritingException(aterm.toString());
   }
 
@@ -55,7 +56,7 @@ import org.spoofax.interpreter.core.Tools;
     return aterm;
   }
 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     return specialize(1).exec_default(_1, _2, _3, _4);
   }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Get_3.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Get_3.java
@@ -92,39 +92,39 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in22200 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in30200 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in30200 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in30200 = _4;
-    final A_Expr lifted_19940000 = this._1;
-    final A_Type lifted_19950000 = this._2;
-    final String f9300000 = this._3;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in25400 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in27600 = _2;
+    final A_This this_in24600 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in27600 = _4;
+    final A_Expr lifted_44670000 = this._1;
+    final A_Type lifted_44680000 = this._2;
+    final String f1204000000 = this._3;
     { 
-      final A_This this_123200 = this_in22200;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_130700 = env_in30200;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_136300 = c_in30200;
-      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_130700 = store_in30200;
-      final R_default_V $tmp618 = lifted_19940000.exec_default(this_123200, env_130700, c_136300, store_130700);
-      final A_V lifted_2141000 = $tmp618.value;
-      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_222400 = $tmp618.get_1();
-      final o2v_1 $tmp619 = lifted_2141000.match(o2v_1.class);
-      if($tmp619 != null)
+      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_126500 = l_string_class_in25400;
+      final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_128000 = l_string_v_in27600;
+      final A_This this_125400 = this_in24600;
+      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_128000 = l_int_v_in27600;
+      final R_default_V $tmp1082 = lifted_44670000.exec_default(l_string_class_126500, l_string_v_128000, this_125400, l_int_v_128000);
+      final A_V lifted_4604000 = $tmp1082.value;
+      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_221100 = $tmp1082.get_1();
+      final o2v_1 $tmp1083 = lifted_4604000.match(o2v_1.class);
+      if($tmp1083 != null)
       { 
-        final A_Obj o9200000 = $tmp619.get_1();
-        final ClassT_1 $tmp620 = lifted_19950000.match(ClassT_1.class);
-        if($tmp620 != null)
+        final A_Obj o606000000 = $tmp1083.get_1();
+        final ClassT_1 $tmp1084 = lifted_44680000.match(ClassT_1.class);
+        if($tmp1084 != null)
         { 
-          final String c17800000 = $tmp620.get_1();
-          final readField_3 lifted_19960000 = new readField_3(this.getSourceInfo(), o9200000, c17800000, f9300000);
-          final R_default_V $tmp621 = lifted_19960000.exec_default(this_123200, env_130700, c_136300, store_222400);
-          final A_V lifted_2143000 = $tmp621.value;
-          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_314300 = $tmp621.get_1();
-          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out30200 = store_314300;
-          final A_V result_out30200 = lifted_2143000;
-          return new R_default_V(result_out30200, store_out30200);
+          final String c1275000000 = $tmp1084.get_1();
+          final readField_3 lifted_44690000 = new readField_3(this.getSourceInfo(), o606000000, c1275000000, f1204000000);
+          final R_default_V $tmp1085 = lifted_44690000.exec_default(l_string_class_126500, l_string_v_128000, this_125400, l_int_v_221100);
+          final A_V lifted_4606000 = $tmp1085.value;
+          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_313600 = $tmp1085.get_1();
+          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out27500 = l_int_v_313600;
+          final A_V result_out55300 = lifted_4606000;
+          return new R_default_V(result_out55300, l_int_v_out27500);
         }
         else
         { }
@@ -154,7 +154,7 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)
   { 
-    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("Get", 3), _1.toStrategoTerm(factory), _2.toStrategoTerm(factory), factory.makeString(_3));
+    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("Get", 3), _1.toStrategoTerm(factory), _2.toStrategoTerm(factory), TermUtils.termFromString(_3, factory));
     if(getSourceInfo() != null)
     { 
       getSourceInfo().apply(term);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/If_3.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/If_3.java
@@ -96,47 +96,47 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in21700 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in29700 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in29700 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in29700 = _4;
-    final A_Expr lifted_19920000 = this._1;
-    final A_Expr lifted_18570000 = this._2;
-    final A_Expr e7400000 = this._3;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in25000 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in27200 = _2;
+    final A_This this_in24200 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in27200 = _4;
+    final A_Expr lifted_44650000 = this._1;
+    final A_Expr lifted_43390000 = this._2;
+    final A_Expr e530000000 = this._3;
     { 
-      final A_This this_122700 = this_in21700;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_130300 = env_in29700;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_135400 = c_in29700;
-      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_130300 = store_in29700;
-      final R_default_V $tmp604 = lifted_19920000.exec_default(this_122700, env_130300, c_135400, store_130300);
-      final A_V lifted_2137000 = $tmp604.value;
-      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_221800 = $tmp604.get_1();
-      final BoolV_1 $tmp605 = lifted_2137000.match(BoolV_1.class);
-      if($tmp605 != null)
+      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_126100 = l_string_class_in25000;
+      final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_127600 = l_string_v_in27200;
+      final A_This this_124900 = this_in24200;
+      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_127600 = l_int_v_in27200;
+      final R_default_V $tmp1068 = lifted_44650000.exec_default(l_string_class_126100, l_string_v_127600, this_124900, l_int_v_127600);
+      final A_V lifted_4601000 = $tmp1068.value;
+      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_220500 = $tmp1068.get_1();
+      final BoolV_1 $tmp1069 = lifted_4601000.match(BoolV_1.class);
+      if($tmp1069 != null)
       { 
-        final boolean lifted_19930000 = $tmp605.get_1();
-        if(lifted_19930000 == true)
+        final boolean lifted_44660000 = $tmp1069.get_1();
+        if(lifted_44660000 == true)
         { 
-          final R_default_V $tmp606 = lifted_18570000.exec_default(this_122700, env_130300, c_135400, store_221800);
-          final A_V lifted_2135000 = $tmp606.value;
-          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_313800 = $tmp606.get_1();
-          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out29700 = store_313800;
-          final A_V result_out29700 = lifted_2135000;
-          return new R_default_V(result_out29700, store_out29700);
+          final R_default_V $tmp1070 = lifted_43390000.exec_default(l_string_class_126100, l_string_v_127600, this_124900, l_int_v_220500);
+          final A_V lifted_4599000 = $tmp1070.value;
+          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_313200 = $tmp1070.get_1();
+          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out27100 = l_int_v_313200;
+          final A_V result_out54900 = lifted_4599000;
+          return new R_default_V(result_out54900, l_int_v_out27100);
         }
         else
         { 
-          if(lifted_19930000 == false)
+          if(lifted_44660000 == false)
           { 
-            final R_default_V $tmp607 = e7400000.exec_default(this_122700, env_130300, c_135400, store_221800);
-            final A_V lifted_2138000 = $tmp607.value;
-            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_313900 = $tmp607.get_1();
-            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out29700 = store_313900;
-            final A_V result_out29700 = lifted_2138000;
-            return new R_default_V(result_out29700, store_out29700);
+            final R_default_V $tmp1071 = e530000000.exec_default(l_string_class_126100, l_string_v_127600, this_124900, l_int_v_220500);
+            final A_V lifted_4602000 = $tmp1071.value;
+            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_313300 = $tmp1071.get_1();
+            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out27100 = l_int_v_313300;
+            final A_V result_out54900 = lifted_4602000;
+            return new R_default_V(result_out54900, l_int_v_out27100);
           }
           else
           { }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/L_A_Expr.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/L_A_Expr.java
@@ -116,42 +116,42 @@ public class L_A_Expr  implements INodeList
     return list;
   }
 
-  public R_default_List_V_ exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_List_V_ exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in2350 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in3160 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in3160 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in3160 = _4;
-    final L_A_Expr lifted_20580000 = this;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in2660 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in2880 = _2;
+    final A_This this_in2590 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in2880 = _4;
+    final L_A_Expr lifted_45270000 = this;
     { 
-      final A_This this_124500 = this_in2350;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_132100 = env_in3160;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_138300 = c_in3160;
-      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_132100 = store_in3160;
-      if(lifted_20580000 != null && lifted_20580000.equals(new NIL(this.getSourceInfo())))
+      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_127800 = l_string_class_in2660;
+      final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_129100 = l_string_v_in2880;
+      final A_This this_126700 = this_in2590;
+      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_129100 = l_int_v_in2880;
+      if(lifted_45270000 != null && lifted_45270000.equals(new NIL(this.getSourceInfo())))
       { 
-        final L_A_V lifted_20570000 = (L_A_V)new L_A_V(this.getSourceInfo());
-        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out3160 = store_132100;
-        final L_A_V result_out3160 = lifted_20570000;
-        return new R_default_List_V_(result_out3160, store_out3160);
+        final L_A_V lifted_45260000 = (L_A_V)new L_A_V(this.getSourceInfo());
+        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out2870 = l_int_v_129100;
+        final L_A_V result_out5650 = lifted_45260000;
+        return new R_default_List_V_(result_out5650, l_int_v_out2870);
       }
       else
       { 
-        if(lifted_20580000 != null && !lifted_20580000.isEmpty())
+        if(lifted_45270000 != null && !lifted_45270000.isEmpty())
         { 
-          final A_Expr lifted_20600000 = lifted_20580000.head();
-          final L_A_Expr es700000 = lifted_20580000.tail();
-          final R_default_V $tmp640 = lifted_20600000.exec_default(this_124500, env_132100, c_138300, store_132100);
-          final A_V v16300000 = $tmp640.value;
-          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_223100 = $tmp640.get_1();
-          final R_default_List_V_ $tmp641 = es700000.exec_default(this_124500, env_132100, c_138300, store_223100);
-          final L_A_V vs3100000 = $tmp641.value;
-          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_314700 = $tmp641.get_1();
-          final L_A_V lifted_20590000 = new L_A_V(this.getSourceInfo(), v16300000, vs3100000);
-          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out3160 = store_314700;
-          final L_A_V result_out3160 = lifted_20590000;
-          return new R_default_List_V_(result_out3160, store_out3160);
+          final A_Expr lifted_45290000 = lifted_45270000.head();
+          final L_A_Expr es61000000 = lifted_45270000.tail();
+          final R_default_V $tmp1104 = lifted_45290000.exec_default(l_string_class_127800, l_string_v_129100, this_126700, l_int_v_129100);
+          final A_V v1191000000 = $tmp1104.value;
+          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_221700 = $tmp1104.get_1();
+          final R_default_List_V_ $tmp1105 = es61000000.exec_default(l_string_class_127800, l_string_v_129100, this_126700, l_int_v_221700);
+          final L_A_V vs151000000 = $tmp1105.value;
+          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_314200 = $tmp1105.get_1();
+          final L_A_V lifted_45280000 = new L_A_V(this.getSourceInfo(), v1191000000, vs151000000);
+          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out2870 = l_int_v_314200;
+          final L_A_V result_out5650 = lifted_45280000;
+          return new R_default_List_V_(result_out5650, l_int_v_out2870);
         }
         else
         { }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/L_A_Param.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/L_A_Param.java
@@ -116,44 +116,44 @@ public class L_A_Param  implements INodeList
     return list;
   }
 
-  public R_default_List_String_ exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_List_String_ exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in2360 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in3170 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in3170 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in3170 = _4;
-    final L_A_Param lifted_20630000 = this;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in2670 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in2890 = _2;
+    final A_This this_in2610 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in2890 = _4;
+    final L_A_Param lifted_45320000 = this;
     { 
-      final A_This this_124700 = this_in2360;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_132300 = env_in3170;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_138500 = c_in3170;
-      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_132300 = store_in3170;
-      if(lifted_20630000 != null && lifted_20630000.equals(new NIL(this.getSourceInfo())))
+      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_128000 = l_string_class_in2670;
+      final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_129300 = l_string_v_in2890;
+      final A_This this_126900 = this_in2610;
+      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_129300 = l_int_v_in2890;
+      if(lifted_45320000 != null && lifted_45320000.equals(new NIL(this.getSourceInfo())))
       { 
-        final L_String lifted_20620000 = (L_String)new L_String(this.getSourceInfo());
-        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out3170 = store_132300;
-        final L_String result_out3170 = lifted_20620000;
-        return new R_default_List_String_(result_out3170, store_out3170);
+        final L_String lifted_45310000 = (L_String)new L_String(this.getSourceInfo());
+        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out2880 = l_int_v_129300;
+        final L_String result_out5660 = lifted_45310000;
+        return new R_default_List_String_(result_out5660, l_int_v_out2880);
       }
       else
       { 
-        if(lifted_20630000 != null && !lifted_20630000.isEmpty())
+        if(lifted_45320000 != null && !lifted_45320000.isEmpty())
         { 
-          final A_Param lifted_20650000 = lifted_20630000.head();
-          final L_A_Param params2300000 = lifted_20630000.tail();
-          final Param_2 $tmp642 = lifted_20650000.match(Param_2.class);
-          if($tmp642 != null)
+          final A_Param lifted_45340000 = lifted_45320000.head();
+          final L_A_Param params186000000 = lifted_45320000.tail();
+          final Param_2 $tmp1106 = lifted_45340000.match(Param_2.class);
+          if($tmp1106 != null)
           { 
-            final A_Type lifted_18660000 = $tmp642.get_1();
-            final String x51600000 = $tmp642.get_2();
-            final R_default_List_String_ $tmp643 = params2300000.exec_default(this_124700, env_132300, c_138500, store_132300);
-            final L_String xs3100000 = $tmp643.value;
-            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_223200 = $tmp643.get_1();
-            final L_String lifted_20640000 = new L_String(this.getSourceInfo(), x51600000, xs3100000);
-            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out3170 = store_223200;
-            final L_String result_out3170 = lifted_20640000;
-            return new R_default_List_String_(result_out3170, store_out3170);
+            final A_Type lifted_43470000 = $tmp1106.get_1();
+            final String x597000000 = $tmp1106.get_2();
+            final R_default_List_String_ $tmp1107 = params186000000.exec_default(l_string_class_128000, l_string_v_129300, this_126900, l_int_v_129300);
+            final L_String xs188000000 = $tmp1107.value;
+            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_221800 = $tmp1107.get_1();
+            final L_String lifted_45330000 = new L_String(this.getSourceInfo(), x597000000, xs188000000);
+            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out2880 = l_int_v_221800;
+            final L_String result_out5660 = lifted_45330000;
+            return new R_default_List_String_(result_out5660, l_int_v_out2880);
           }
           else
           { }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Let_2.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Let_2.java
@@ -85,55 +85,55 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in22100 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in30100 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in30100 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in30100 = _4;
-    final L_A_Bind lifted_19450000 = this._1;
-    final A_Expr e7200000 = this._2;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in25300 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in27500 = _2;
+    final A_This this_in24500 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in27500 = _4;
+    final L_A_Bind lifted_44190000 = this._1;
+    final A_Expr e528000000 = this._2;
     { 
-      final A_This this_123100 = this_in22100;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_130600 = env_in30100;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_136200 = c_in30100;
-      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_130600 = store_in30100;
-      if(lifted_19450000 != null && lifted_19450000.equals(new NIL(this.getSourceInfo())))
+      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_126400 = l_string_class_in25300;
+      final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_127900 = l_string_v_in27500;
+      final A_This this_125300 = this_in24500;
+      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_127900 = l_int_v_in27500;
+      if(lifted_44190000 != null && lifted_44190000.equals(new NIL(this.getSourceInfo())))
       { 
-        final R_default_V $tmp613 = e7200000.exec_default(this_123100, env_130600, c_136200, store_130600);
-        final A_V v15400000 = $tmp613.value;
-        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_222200 = $tmp613.get_1();
-        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out30100 = store_222200;
-        final A_V result_out30100 = v15400000;
-        return new R_default_V(result_out30100, store_out30100);
+        final R_default_V $tmp1077 = e528000000.exec_default(l_string_class_126400, l_string_v_127900, this_125300, l_int_v_127900);
+        final A_V v1183000000 = $tmp1077.value;
+        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_220800 = $tmp1077.get_1();
+        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out27400 = l_int_v_220800;
+        final A_V result_out55200 = v1183000000;
+        return new R_default_V(result_out55200, l_int_v_out27400);
       }
       else
       { 
-        if(lifted_19450000 != null && !lifted_19450000.isEmpty())
+        if(lifted_44190000 != null && !lifted_44190000.isEmpty())
         { 
-          final A_Bind lifted_19460000 = lifted_19450000.head();
-          final L_A_Bind binds700000 = lifted_19450000.tail();
-          final Bind_3 $tmp614 = lifted_19460000.match(Bind_3.class);
-          if($tmp614 != null)
+          final A_Bind lifted_44200000 = lifted_44190000.head();
+          final L_A_Bind binds61000000 = lifted_44190000.tail();
+          final Bind_3 $tmp1078 = lifted_44200000.match(Bind_3.class);
+          if($tmp1078 != null)
           { 
-            final A_Type lifted_18480000 = $tmp614.get_1();
-            final String x51300000 = $tmp614.get_2();
-            final A_Expr lifted_19510000 = $tmp614.get_3();
-            final R_default_V $tmp615 = lifted_19510000.exec_default(this_123100, env_130600, c_136200, store_130600);
-            final A_V v15500000 = $tmp615.value;
-            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_222300 = $tmp615.get_1();
-            final bindVar_2 lifted_19470000 = new bindVar_2(this.getSourceInfo(), x51300000, v15500000);
-            final Let_2 lifted_19480000 = new Let_2(this.getSourceInfo(), binds700000, e7200000);
-            final R_default_Env $tmp616 = lifted_19470000.exec_default(this_123100, env_130600, c_136200, store_222300);
-            final com.github.krukow.clj_ds.PersistentMap<String, A_V> lifted_2114000 = $tmp616.value;
-            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_314200 = $tmp616.get_1();
-            final R_default_V $tmp617 = lifted_19480000.exec_default(this_123100, lifted_2114000, c_136200, store_314200);
-            final A_V v_1400000 = $tmp617.value;
-            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_43100 = $tmp617.get_1();
-            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out30100 = store_43100;
-            final A_V result_out30100 = v_1400000;
-            return new R_default_V(result_out30100, store_out30100);
+            final A_Type lifted_43310000 = $tmp1078.get_1();
+            final String x594000000 = $tmp1078.get_2();
+            final A_Expr lifted_44240000 = $tmp1078.get_3();
+            final R_default_V $tmp1079 = lifted_44240000.exec_default(l_string_class_126400, l_string_v_127900, this_125300, l_int_v_127900);
+            final A_V v1184000000 = $tmp1079.value;
+            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_220900 = $tmp1079.get_1();
+            final bindVar_2 lifted_44210000 = new bindVar_2(this.getSourceInfo(), x594000000, v1184000000);
+            final Let_2 lifted_44220000 = new Let_2(this.getSourceInfo(), binds61000000, e528000000);
+            final R_default_Map_String_V_ $tmp1080 = lifted_44210000.exec_default(l_string_class_126400, l_string_v_127900, this_125300, l_int_v_220900);
+            final com.github.krukow.clj_ds.PersistentMap<String, A_V> lifted_4580000 = $tmp1080.value;
+            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_313500 = $tmp1080.get_1();
+            final R_default_V $tmp1081 = lifted_44220000.exec_default(l_string_class_126400, lifted_4580000, this_125300, l_int_v_313500);
+            final A_V v_122000000 = $tmp1081.value;
+            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_42800 = $tmp1081.get_1();
+            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out27400 = l_int_v_42800;
+            final A_V result_out55200 = v_122000000;
+            return new R_default_V(result_out55200, l_int_v_out27400);
           }
           else
           { }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Lt_2.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Lt_2.java
@@ -77,39 +77,39 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in21600 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in29600 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in29600 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in29600 = _4;
-    final A_Expr lifted_19270000 = this._1;
-    final A_Expr lifted_19280000 = this._2;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in24900 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in27100 = _2;
+    final A_This this_in24100 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in27100 = _4;
+    final A_Expr lifted_44030000 = this._1;
+    final A_Expr lifted_44040000 = this._2;
     { 
-      final A_This this_122600 = this_in21600;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_130200 = env_in29600;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_135300 = c_in29600;
-      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_130200 = store_in29600;
-      final R_default_V $tmp600 = lifted_19270000.exec_default(this_122600, env_130200, c_135300, store_130200);
-      final A_V lifted_2108000 = $tmp600.value;
-      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_221700 = $tmp600.get_1();
-      final NumV_1 $tmp601 = lifted_2108000.match(NumV_1.class);
-      if($tmp601 != null)
+      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_126000 = l_string_class_in24900;
+      final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_127500 = l_string_v_in27100;
+      final A_This this_124800 = this_in24100;
+      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_127500 = l_int_v_in27100;
+      final R_default_V $tmp1064 = lifted_44030000.exec_default(l_string_class_126000, l_string_v_127500, this_124800, l_int_v_127500);
+      final A_V lifted_4574000 = $tmp1064.value;
+      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_220400 = $tmp1064.get_1();
+      final NumV_1 $tmp1065 = lifted_4574000.match(NumV_1.class);
+      if($tmp1065 != null)
       { 
-        final int i6700000 = $tmp601.get_1();
-        final R_default_V $tmp602 = lifted_19280000.exec_default(this_122600, env_130200, c_135300, store_221700);
-        final A_V lifted_2107000 = $tmp602.value;
-        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_313700 = $tmp602.get_1();
-        final NumV_1 $tmp603 = lifted_2107000.match(NumV_1.class);
-        if($tmp603 != null)
+        final int i511000000 = $tmp1065.get_1();
+        final R_default_V $tmp1066 = lifted_44040000.exec_default(l_string_class_126000, l_string_v_127500, this_124800, l_int_v_220400);
+        final A_V lifted_4573000 = $tmp1066.value;
+        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_312900 = $tmp1066.get_1();
+        final NumV_1 $tmp1067 = lifted_4573000.match(NumV_1.class);
+        if($tmp1067 != null)
         { 
-          final int j4400000 = $tmp603.get_1();
-          final boolean lifted_19310000 = ds.manual.interpreter.Natives.gtI_2(j4400000, i6700000);
-          final BoolV_1 lifted_19290000 = new BoolV_1(this.getSourceInfo(), lifted_19310000);
-          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out29600 = store_313700;
-          final A_V result_out29600 = lifted_19290000;
-          return new R_default_V(result_out29600, store_out29600);
+          final int j263000000 = $tmp1067.get_1();
+          final boolean lifted_44060000 = ds.manual.interpreter.Natives.gtI_2(j263000000, i511000000);
+          final BoolV_1 lifted_44050000 = new BoolV_1(this.getSourceInfo(), lifted_44060000);
+          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out27000 = l_int_v_312900;
+          final A_V result_out54800 = lifted_44050000;
+          return new R_default_V(result_out54800, l_int_v_out27000);
         }
         else
         { }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Method_4.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Method_4.java
@@ -141,7 +141,7 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)
   { 
-    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("Method", 4), _1.toStrategoTerm(factory), factory.makeString(_2), _3.toStrategoTerm(factory), _4.toStrategoTerm(factory));
+    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("Method", 4), _1.toStrategoTerm(factory), TermUtils.termFromString(_2, factory), _3.toStrategoTerm(factory), _4.toStrategoTerm(factory));
     if(getSourceInfo() != null)
     { 
       getSourceInfo().apply(term);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Min_1.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Min_1.java
@@ -58,32 +58,32 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in20300 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in28400 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in28400 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in28400 = _4;
-    final A_Expr lifted_19230000 = this._1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in23800 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in26000 = _2;
+    final A_This this_in22700 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in26000 = _4;
+    final A_Expr lifted_43990000 = this._1;
     { 
-      final A_This this_121400 = this_in20300;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_128900 = env_in28400;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_133800 = c_in28400;
-      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_128900 = store_in28400;
-      final R_default_V $tmp573 = lifted_19230000.exec_default(this_121400, env_128900, c_133800, store_128900);
-      final A_V lifted_2106000 = $tmp573.value;
-      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_220600 = $tmp573.get_1();
-      final NumV_1 $tmp574 = lifted_2106000.match(NumV_1.class);
-      if($tmp574 != null)
+      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_124900 = l_string_class_in23800;
+      final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_126400 = l_string_v_in26000;
+      final A_This this_123600 = this_in22700;
+      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_126400 = l_int_v_in26000;
+      final R_default_V $tmp1037 = lifted_43990000.exec_default(l_string_class_124900, l_string_v_126400, this_123600, l_int_v_126400);
+      final A_V lifted_4572000 = $tmp1037.value;
+      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_219500 = $tmp1037.get_1();
+      final NumV_1 $tmp1038 = lifted_4572000.match(NumV_1.class);
+      if($tmp1038 != null)
       { 
-        final int i6600000 = $tmp574.get_1();
-        final int lifted_19260000 = 0;
-        final int lifted_19250000 = ds.manual.interpreter.Natives.minusI_2(lifted_19260000, i6600000);
-        final NumV_1 lifted_19240000 = new NumV_1(this.getSourceInfo(), lifted_19250000);
-        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out28400 = store_220600;
-        final A_V result_out28400 = lifted_19240000;
-        return new R_default_V(result_out28400, store_out28400);
+        final int i510000000 = $tmp1038.get_1();
+        final int lifted_44020000 = 0;
+        final int lifted_44010000 = ds.manual.interpreter.Natives.minusI_2(lifted_44020000, i510000000);
+        final NumV_1 lifted_44001000 = new NumV_1(this.getSourceInfo(), lifted_44010000);
+        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out25900 = l_int_v_219500;
+        final A_V result_out53700 = lifted_44001000;
+        return new R_default_V(result_out53700, l_int_v_out25900);
       }
       else
       { }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Mul_2.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Mul_2.java
@@ -77,39 +77,39 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in20600 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in28700 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in28700 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in28700 = _4;
-    final A_Expr lifted_19180000 = this._1;
-    final A_Expr lifted_19190000 = this._2;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in24100 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in26300 = _2;
+    final A_This this_in23200 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in26300 = _4;
+    final A_Expr lifted_43950000 = this._1;
+    final A_Expr lifted_43960000 = this._2;
     { 
-      final A_This this_121700 = this_in20600;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_129300 = env_in28700;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_134300 = c_in28700;
-      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_129300 = store_in28700;
-      final R_default_V $tmp583 = lifted_19180000.exec_default(this_121700, env_129300, c_134300, store_129300);
-      final A_V lifted_2105000 = $tmp583.value;
-      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_220900 = $tmp583.get_1();
-      final NumV_1 $tmp584 = lifted_2105000.match(NumV_1.class);
-      if($tmp584 != null)
+      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_125200 = l_string_class_in24100;
+      final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_126700 = l_string_v_in26300;
+      final A_This this_123900 = this_in23200;
+      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_126700 = l_int_v_in26300;
+      final R_default_V $tmp1047 = lifted_43950000.exec_default(l_string_class_125200, l_string_v_126700, this_123900, l_int_v_126700);
+      final A_V lifted_4571000 = $tmp1047.value;
+      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_219800 = $tmp1047.get_1();
+      final NumV_1 $tmp1048 = lifted_4571000.match(NumV_1.class);
+      if($tmp1048 != null)
       { 
-        final int i6500000 = $tmp584.get_1();
-        final R_default_V $tmp585 = lifted_19190000.exec_default(this_121700, env_129300, c_134300, store_220900);
-        final A_V lifted_2104000 = $tmp585.value;
-        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_313300 = $tmp585.get_1();
-        final NumV_1 $tmp586 = lifted_2104000.match(NumV_1.class);
-        if($tmp586 != null)
+        final int i509000000 = $tmp1048.get_1();
+        final R_default_V $tmp1049 = lifted_43960000.exec_default(l_string_class_125200, l_string_v_126700, this_123900, l_int_v_219800);
+        final A_V lifted_4570000 = $tmp1049.value;
+        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_312500 = $tmp1049.get_1();
+        final NumV_1 $tmp1050 = lifted_4570000.match(NumV_1.class);
+        if($tmp1050 != null)
         { 
-          final int j4300000 = $tmp586.get_1();
-          final int lifted_19220000 = ds.manual.interpreter.Natives.timesI_2(i6500000, j4300000);
-          final NumV_1 lifted_19210000 = new NumV_1(this.getSourceInfo(), lifted_19220000);
-          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out28700 = store_313300;
-          final A_V result_out28700 = lifted_19210000;
-          return new R_default_V(result_out28700, store_out28700);
+          final int j262000000 = $tmp1050.get_1();
+          final int lifted_43980000 = ds.manual.interpreter.Natives.timesI_2(i509000000, j262000000);
+          final NumV_1 lifted_43970000 = new NumV_1(this.getSourceInfo(), lifted_43980000);
+          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out26200 = l_int_v_312500;
+          final A_V result_out54000 = lifted_43970000;
+          return new R_default_V(result_out54000, l_int_v_out26200);
         }
         else
         { }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Neq_2.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Neq_2.java
@@ -77,27 +77,27 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in21500 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in29500 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in29500 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in29500 = _4;
-    final A_Expr e13200000 = this._1;
-    final A_Expr e23100000 = this._2;
-    final A_This this_122500 = this_in21500;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_130100 = env_in29500;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_135200 = c_in29500;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_130100 = store_in29500;
-    final Eq_2 lifted_19170000 = new Eq_2(this.getSourceInfo(), e13200000, e23100000);
-    final Not_1 lifted_19160000 = new Not_1(this.getSourceInfo(), lifted_19170000);
-    final R_default_V $tmp599 = lifted_19160000.exec_default(this_122500, env_130100, c_135200, store_130100);
-    final A_V lifted_2102000 = $tmp599.value;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_221600 = $tmp599.get_1();
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out29500 = store_221600;
-    final A_V result_out29500 = lifted_2102000;
-    return new R_default_V(result_out29500, store_out29500);
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in24800 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in27000 = _2;
+    final A_This this_in23900 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in27000 = _4;
+    final A_Expr e1180000000 = this._1;
+    final A_Expr e2139000000 = this._2;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_125900 = l_string_class_in24800;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_127400 = l_string_v_in27000;
+    final A_This this_124700 = this_in23900;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_127400 = l_int_v_in27000;
+    final Eq_2 lifted_43940000 = new Eq_2(this.getSourceInfo(), e1180000000, e2139000000);
+    final Not_1 lifted_43930000 = new Not_1(this.getSourceInfo(), lifted_43940000);
+    final R_default_V $tmp1063 = lifted_43930000.exec_default(l_string_class_125900, l_string_v_127400, this_124700, l_int_v_127400);
+    final A_V lifted_4568000 = $tmp1063.value;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_220300 = $tmp1063.get_1();
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out26900 = l_int_v_220300;
+    final A_V result_out54700 = lifted_4568000;
+    return new R_default_V(result_out54700, l_int_v_out26900);
   }
 
   public A_Expr get_1()

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/New_1.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/New_1.java
@@ -54,30 +54,30 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in22500 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in30500 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in30500 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in30500 = _4;
-    final String c16800000 = this._1;
-    final A_This this_123500 = this_in22500;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_131200 = env_in30500;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_136600 = c_in30500;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_131200 = store_in30500;
-    final loadClass_1 lifted_19150000 = new loadClass_1(this.getSourceInfo(), c16800000);
-    final R_default_Class $tmp635 = lifted_19150000.exec_default(this_123500, env_131200, c_136600, store_131200);
-    final A_Class lifted_2096000 = $tmp635.value;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_222700 = $tmp635.get_1();
-    final initObject_1 lifted_19140000 = new initObject_1(this.getSourceInfo(), lifted_2096000);
-    final R_default_Obj $tmp636 = lifted_19140000.exec_default(this_123500, env_131200, c_136600, store_222700);
-    final A_Obj lifted_2099000 = $tmp636.value;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_314600 = $tmp636.get_1();
-    final o2v_1 lifted_2098000 = new o2v_1(this.getSourceInfo(), lifted_2099000);
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out30500 = store_314600;
-    final A_V result_out30500 = lifted_2098000;
-    return new R_default_V(result_out30500, store_out30500);
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in25700 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in27900 = _2;
+    final A_This this_in24900 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in27900 = _4;
+    final String c1265000000 = this._1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_126800 = l_string_class_in25700;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_128300 = l_string_v_in27900;
+    final A_This this_125700 = this_in24900;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_128300 = l_int_v_in27900;
+    final loadClass_1 lifted_43920000 = new loadClass_1(this.getSourceInfo(), c1265000000);
+    final R_default_Class $tmp1099 = lifted_43920000.exec_default(l_string_class_126800, l_string_v_128300, this_125700, l_int_v_128300);
+    final A_Class lifted_4563000 = $tmp1099.value;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_221400 = $tmp1099.get_1();
+    final initObject_1 lifted_43910000 = new initObject_1(this.getSourceInfo(), lifted_4563000);
+    final R_default_Obj $tmp1100 = lifted_43910000.exec_default(l_string_class_126800, l_string_v_128300, this_125700, l_int_v_221400);
+    final A_Obj lifted_4566000 = $tmp1100.value;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_313900 = $tmp1100.get_1();
+    final o2v_1 lifted_4565000 = new o2v_1(this.getSourceInfo(), lifted_4566000);
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out27800 = l_int_v_313900;
+    final A_V result_out55600 = lifted_4565000;
+    return new R_default_V(result_out55600, l_int_v_out27800);
   }
 
   public String get_1()
@@ -87,7 +87,7 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)
   { 
-    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("New", 1), factory.makeString(_1));
+    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("New", 1), TermUtils.termFromString(_1, factory));
     if(getSourceInfo() != null)
     { 
       getSourceInfo().apply(term);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Not_1.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Not_1.java
@@ -58,43 +58,43 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in20900 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in29100 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in29100 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in29100 = _4;
-    final A_Expr lifted_19080000 = this._1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in24400 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in26600 = _2;
+    final A_This this_in23500 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in26600 = _4;
+    final A_Expr lifted_43870000 = this._1;
     { 
-      final A_This this_122100 = this_in20900;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_129600 = env_in29100;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_134700 = c_in29100;
-      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_129600 = store_in29100;
-      final R_default_V $tmp587 = lifted_19080000.exec_default(this_122100, env_129600, c_134700, store_129600);
-      final A_V lifted_2095000 = $tmp587.value;
-      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_221200 = $tmp587.get_1();
-      final BoolV_1 $tmp588 = lifted_2095000.match(BoolV_1.class);
-      if($tmp588 != null)
+      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_125500 = l_string_class_in24400;
+      final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_127000 = l_string_v_in26600;
+      final A_This this_124300 = this_in23500;
+      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_127000 = l_int_v_in26600;
+      final R_default_V $tmp1051 = lifted_43870000.exec_default(l_string_class_125500, l_string_v_127000, this_124300, l_int_v_127000);
+      final A_V lifted_4562000 = $tmp1051.value;
+      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_219900 = $tmp1051.get_1();
+      final BoolV_1 $tmp1052 = lifted_4562000.match(BoolV_1.class);
+      if($tmp1052 != null)
       { 
-        final boolean lifted_19120000 = $tmp588.get_1();
-        if(lifted_19120000 == true)
+        final boolean lifted_43890000 = $tmp1052.get_1();
+        if(lifted_43890000 == true)
         { 
-          final boolean lifted_19070000 = false;
-          final BoolV_1 lifted_19050000 = new BoolV_1(this.getSourceInfo(), lifted_19070000);
-          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out29100 = store_221200;
-          final A_V result_out29100 = lifted_19050000;
-          return new R_default_V(result_out29100, store_out29100);
+          final boolean lifted_43860000 = false;
+          final BoolV_1 lifted_43840000 = new BoolV_1(this.getSourceInfo(), lifted_43860000);
+          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out26500 = l_int_v_219900;
+          final A_V result_out54300 = lifted_43840000;
+          return new R_default_V(result_out54300, l_int_v_out26500);
         }
         else
         { 
-          if(lifted_19120000 == false)
+          if(lifted_43890000 == false)
           { 
-            final boolean lifted_19130000 = true;
-            final BoolV_1 lifted_19090000 = new BoolV_1(this.getSourceInfo(), lifted_19130000);
-            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out29100 = store_221200;
-            final A_V result_out29100 = lifted_19090000;
-            return new R_default_V(result_out29100, store_out29100);
+            final boolean lifted_43900000 = true;
+            final BoolV_1 lifted_43880000 = new BoolV_1(this.getSourceInfo(), lifted_43900000);
+            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out26500 = l_int_v_219900;
+            final A_V result_out54300 = lifted_43880000;
+            return new R_default_V(result_out54300, l_int_v_out26500);
           }
           else
           { }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Null_1.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Null_1.java
@@ -54,22 +54,22 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in22700 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in30700 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in30700 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in30700 = _4;
-    final String lifted_18430000 = this._1;
-    final A_This this_123600 = this_in22700;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_131400 = env_in30700;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_137400 = c_in30700;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_131400 = store_in30700;
-    final NullV_0 lifted_19030000 = new NullV_0(this.getSourceInfo());
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out30700 = store_131400;
-    final A_V result_out30700 = lifted_19030000;
-    return new R_default_V(result_out30700, store_out30700);
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in25900 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in28100 = _2;
+    final A_This this_in25200 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in28100 = _4;
+    final String lifted_43260000 = this._1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_127000 = l_string_class_in25900;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_128500 = l_string_v_in28100;
+    final A_This this_125800 = this_in25200;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_128500 = l_int_v_in28100;
+    final NullV_0 lifted_43820000 = new NullV_0(this.getSourceInfo());
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out28000 = l_int_v_128500;
+    final A_V result_out55800 = lifted_43820000;
+    return new R_default_V(result_out55800, l_int_v_out28000);
   }
 
   public String get_1()
@@ -79,7 +79,7 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)
   { 
-    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("Null", 1), factory.makeString(_1));
+    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("Null", 1), TermUtils.termFromString(_1, factory));
     if(getSourceInfo() != null)
     { 
       getSourceInfo().apply(term);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/NumV_1.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/NumV_1.java
@@ -53,7 +53,7 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)
   { 
-    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("NumV", 1), factory.makeInt(_1));
+    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("NumV", 1), TermUtils.termFromInt(_1, factory));
     if(getSourceInfo() != null)
     { 
       getSourceInfo().apply(term);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Num_1.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Num_1.java
@@ -54,23 +54,23 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in20200 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in28300 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in28300 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in28300 = _4;
-    final String i6400000 = this._1;
-    final A_This this_121300 = this_in20200;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_128800 = env_in28300;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_133700 = c_in28300;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_128800 = store_in28300;
-    final int lifted_19020000 = ds.manual.interpreter.Natives.str2int_1(i6400000);
-    final NumV_1 lifted_19010000 = new NumV_1(this.getSourceInfo(), lifted_19020000);
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out28300 = store_128800;
-    final A_V result_out28300 = lifted_19010000;
-    return new R_default_V(result_out28300, store_out28300);
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in23700 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in25900 = _2;
+    final A_This this_in22600 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in25900 = _4;
+    final String i508000000 = this._1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_124800 = l_string_class_in23700;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_126300 = l_string_v_in25900;
+    final A_This this_123500 = this_in22600;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_126300 = l_int_v_in25900;
+    final int lifted_43810000 = ds.manual.interpreter.Natives.str2int_1(i508000000);
+    final NumV_1 lifted_43800000 = new NumV_1(this.getSourceInfo(), lifted_43810000);
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out25800 = l_int_v_126300;
+    final A_V result_out53600 = lifted_43800000;
+    return new R_default_V(result_out53600, l_int_v_out25800);
   }
 
   public String get_1()
@@ -80,7 +80,7 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)
   { 
-    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("Num", 1), factory.makeString(_1));
+    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("Num", 1), TermUtils.termFromString(_1, factory));
     if(getSourceInfo() != null)
     { 
       getSourceInfo().apply(term);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/ObjV_4.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/ObjV_4.java
@@ -125,7 +125,7 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)
   { 
-    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("ObjV", 4), factory.makeString(_1), _2.toStrategoTerm(factory), AutoMapUtils.toStrategoTerm_FM(_3, factory), AutoMapUtils.toStrategoTerm_MM(_4, factory));
+    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("ObjV", 4), TermUtils.termFromString(_1, factory), _2.toStrategoTerm(factory), AutoMapUtils.map_String_int2aterm(_3, factory), AutoMapUtils.map_String_A_Method2aterm(_4, factory));
     if(getSourceInfo() != null)
     { 
       getSourceInfo().apply(term);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Or_2.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Or_2.java
@@ -77,45 +77,45 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in21300 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in29300 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in29300 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in29300 = _4;
-    final A_Expr lifted_18980000 = this._1;
-    final A_Expr e7100000 = this._2;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in24600 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in26800 = _2;
+    final A_This this_in23700 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in26800 = _4;
+    final A_Expr lifted_43780000 = this._1;
+    final A_Expr e527000000 = this._2;
     { 
-      final A_This this_122300 = this_in21300;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_129800 = env_in29300;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_134900 = c_in29300;
-      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_129800 = store_in29300;
-      final R_default_V $tmp592 = lifted_18980000.exec_default(this_122300, env_129800, c_134900, store_129800);
-      final A_V lifted_2091000 = $tmp592.value;
-      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_221400 = $tmp592.get_1();
-      final BoolV_1 $tmp593 = lifted_2091000.match(BoolV_1.class);
-      if($tmp593 != null)
+      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_125700 = l_string_class_in24600;
+      final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_127200 = l_string_v_in26800;
+      final A_This this_124500 = this_in23700;
+      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_127200 = l_int_v_in26800;
+      final R_default_V $tmp1056 = lifted_43780000.exec_default(l_string_class_125700, l_string_v_127200, this_124500, l_int_v_127200);
+      final A_V lifted_4558000 = $tmp1056.value;
+      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_220100 = $tmp1056.get_1();
+      final BoolV_1 $tmp1057 = lifted_4558000.match(BoolV_1.class);
+      if($tmp1057 != null)
       { 
-        final boolean lifted_18990000 = $tmp593.get_1();
-        if(lifted_18990000 == true)
+        final boolean lifted_43790000 = $tmp1057.get_1();
+        if(lifted_43790000 == true)
         { 
-          final boolean lifted_18970000 = true;
-          final BoolV_1 lifted_18950000 = new BoolV_1(this.getSourceInfo(), lifted_18970000);
-          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out29300 = store_221400;
-          final A_V result_out29300 = lifted_18950000;
-          return new R_default_V(result_out29300, store_out29300);
+          final boolean lifted_43770000 = true;
+          final BoolV_1 lifted_43750000 = new BoolV_1(this.getSourceInfo(), lifted_43770000);
+          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out26700 = l_int_v_220100;
+          final A_V result_out54500 = lifted_43750000;
+          return new R_default_V(result_out54500, l_int_v_out26700);
         }
         else
         { 
-          if(lifted_18990000 == false)
+          if(lifted_43790000 == false)
           { 
-            final R_default_V $tmp594 = e7100000.exec_default(this_122300, env_129800, c_134900, store_221400);
-            final A_V lifted_2092000 = $tmp594.value;
-            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_313500 = $tmp594.get_1();
-            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out29300 = store_313500;
-            final A_V result_out29300 = lifted_2092000;
-            return new R_default_V(result_out29300, store_out29300);
+            final R_default_V $tmp1058 = e527000000.exec_default(l_string_class_125700, l_string_v_127200, this_124500, l_int_v_220100);
+            final A_V lifted_4559000 = $tmp1058.value;
+            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_312700 = $tmp1058.get_1();
+            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out26700 = l_int_v_312700;
+            final A_V result_out54500 = lifted_4559000;
+            return new R_default_V(result_out54500, l_int_v_out26700);
           }
           else
           { }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Param_2.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Param_2.java
@@ -85,7 +85,7 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)
   { 
-    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("Param", 2), _1.toStrategoTerm(factory), factory.makeString(_2));
+    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("Param", 2), _1.toStrategoTerm(factory), TermUtils.termFromString(_2, factory));
     if(getSourceInfo() != null)
     { 
       getSourceInfo().apply(term);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Program_3.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Program_3.java
@@ -100,30 +100,30 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in20100 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in28200 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in28200 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in28200 = _4;
-    final String lifted_18410000 = this._1;
-    final L_A_Class cs2900000 = this._2;
-    final A_Expr e7000000 = this._3;
-    final A_This this_121200 = this_in20100;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_128700 = env_in28200;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_133600 = c_in28200;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_128700 = store_in28200;
-    final initClasses_1 lifted_18920000 = new initClasses_1(this.getSourceInfo(), cs2900000);
-    final R_default_C $tmp571 = lifted_18920000.exec_default(this_121200, env_128700, c_133600, store_128700);
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> lifted_2087000 = $tmp571.value;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_220500 = $tmp571.get_1();
-    final R_default_V $tmp572 = e7000000.exec_default(this_121200, env_128700, lifted_2087000, store_220500);
-    final A_V v15300000 = $tmp572.value;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_312900 = $tmp572.get_1();
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out28200 = store_312900;
-    final A_V result_out28200 = v15300000;
-    return new R_default_V(result_out28200, store_out28200);
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in23600 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in25800 = _2;
+    final A_This this_in22500 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in25800 = _4;
+    final String lifted_43240000 = this._1;
+    final L_A_Class cs320000000 = this._2;
+    final A_Expr e526000000 = this._3;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_124700 = l_string_class_in23600;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_126200 = l_string_v_in25800;
+    final A_This this_123400 = this_in22500;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_126200 = l_int_v_in25800;
+    final initClasses_1 lifted_43720000 = new initClasses_1(this.getSourceInfo(), cs320000000);
+    final R_default_Map_String_Class_ $tmp1035 = lifted_43720000.exec_default(l_string_class_124700, l_string_v_126200, this_123400, l_int_v_126200);
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> lifted_4555000 = $tmp1035.value;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_219400 = $tmp1035.get_1();
+    final R_default_V $tmp1036 = e526000000.exec_default(lifted_4555000, l_string_v_126200, this_123400, l_int_v_219400);
+    final A_V v1182000000 = $tmp1036.value;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_312200 = $tmp1036.get_1();
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out25700 = l_int_v_312200;
+    final A_V result_out53500 = v1182000000;
+    return new R_default_V(result_out53500, l_int_v_out25700);
   }
 
   public String get_1()
@@ -143,7 +143,7 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)
   { 
-    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("Program", 3), factory.makeString(_1), _2.toStrategoTerm(factory), _3.toStrategoTerm(factory));
+    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("Program", 3), TermUtils.termFromString(_1, factory), _2.toStrategoTerm(factory), _3.toStrategoTerm(factory));
     if(getSourceInfo() != null)
     { 
       getSourceInfo().apply(term);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/R_default_Class.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/R_default_Class.java
@@ -19,7 +19,7 @@ public class R_default_Class  implements IConvertibleToStrategoTerm
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)
   { 
-    return factory.makeAppl(factory.makeConstructor("R_default_Class", 2), value.toStrategoTerm(factory), AutoMapUtils.toStrategoTerm_Store(_1, factory));
+    return factory.makeAppl(factory.makeConstructor("R_default_Class", 2), value.toStrategoTerm(factory), AutoMapUtils.map_int_A_V2aterm(_1, factory));
   }
 
   public com.github.krukow.clj_ds.PersistentMap<Integer, A_V> get_1()

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/R_default_Int.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/R_default_Int.java
@@ -19,7 +19,7 @@ public class R_default_Int  implements IConvertibleToStrategoTerm
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)
   { 
-    return factory.makeAppl(factory.makeConstructor("R_default_Int", 2), factory.makeInt(value), AutoMapUtils.toStrategoTerm_Store(_1, factory));
+    return factory.makeAppl(factory.makeConstructor("R_default_Int", 2), TermUtils.termFromInt(value, factory), AutoMapUtils.map_int_A_V2aterm(_1, factory));
   }
 
   public com.github.krukow.clj_ds.PersistentMap<Integer, A_V> get_1()

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/R_default_List_String_.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/R_default_List_String_.java
@@ -19,7 +19,7 @@ public class R_default_List_String_  implements IConvertibleToStrategoTerm
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)
   { 
-    return factory.makeAppl(factory.makeConstructor("R_default_List_String_", 2), value.toStrategoTerm(factory), AutoMapUtils.toStrategoTerm_Store(_1, factory));
+    return factory.makeAppl(factory.makeConstructor("R_default_List_String_", 2), value.toStrategoTerm(factory), AutoMapUtils.map_int_A_V2aterm(_1, factory));
   }
 
   public com.github.krukow.clj_ds.PersistentMap<Integer, A_V> get_1()

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/R_default_List_V_.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/R_default_List_V_.java
@@ -19,7 +19,7 @@ public class R_default_List_V_  implements IConvertibleToStrategoTerm
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)
   { 
-    return factory.makeAppl(factory.makeConstructor("R_default_List_V_", 2), value.toStrategoTerm(factory), AutoMapUtils.toStrategoTerm_Store(_1, factory));
+    return factory.makeAppl(factory.makeConstructor("R_default_List_V_", 2), value.toStrategoTerm(factory), AutoMapUtils.map_int_A_V2aterm(_1, factory));
   }
 
   public com.github.krukow.clj_ds.PersistentMap<Integer, A_V> get_1()

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/R_default_Map_String_Class_.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/R_default_Map_String_Class_.java
@@ -5,13 +5,13 @@ import org.metaborg.meta.interpreter.framework.IConvertibleToStrategoTerm;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.interpreter.terms.ITermFactory;
 
-public class R_default_FM  implements IConvertibleToStrategoTerm
+public class R_default_Map_String_Class_  implements IConvertibleToStrategoTerm
 { 
-  public final com.github.krukow.clj_ds.PersistentMap<String, Integer> value;
+  public final com.github.krukow.clj_ds.PersistentMap<String, A_Class> value;
 
   public com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _1;
 
-  public R_default_FM (com.github.krukow.clj_ds.PersistentMap<String, Integer> value, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _1) 
+  public R_default_Map_String_Class_ (com.github.krukow.clj_ds.PersistentMap<String, A_Class> value, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _1) 
   { 
     this.value = value;
     this._1 = _1;
@@ -19,7 +19,7 @@ public class R_default_FM  implements IConvertibleToStrategoTerm
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)
   { 
-    return factory.makeAppl(factory.makeConstructor("R_default_FM", 2), AutoMapUtils.toStrategoTerm_FM(value, factory), AutoMapUtils.toStrategoTerm_Store(_1, factory));
+    return factory.makeAppl(factory.makeConstructor("R_default_Map_String_Class_", 2), AutoMapUtils.map_String_A_Class2aterm(value, factory), AutoMapUtils.map_int_A_V2aterm(_1, factory));
   }
 
   public com.github.krukow.clj_ds.PersistentMap<Integer, A_V> get_1()

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/R_default_Map_String_Int_.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/R_default_Map_String_Int_.java
@@ -5,13 +5,13 @@ import org.metaborg.meta.interpreter.framework.IConvertibleToStrategoTerm;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.interpreter.terms.ITermFactory;
 
-public class R_default_Env  implements IConvertibleToStrategoTerm
+public class R_default_Map_String_Int_  implements IConvertibleToStrategoTerm
 { 
-  public final com.github.krukow.clj_ds.PersistentMap<String, A_V> value;
+  public final com.github.krukow.clj_ds.PersistentMap<String, Integer> value;
 
   public com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _1;
 
-  public R_default_Env (com.github.krukow.clj_ds.PersistentMap<String, A_V> value, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _1) 
+  public R_default_Map_String_Int_ (com.github.krukow.clj_ds.PersistentMap<String, Integer> value, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _1) 
   { 
     this.value = value;
     this._1 = _1;
@@ -19,7 +19,7 @@ public class R_default_Env  implements IConvertibleToStrategoTerm
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)
   { 
-    return factory.makeAppl(factory.makeConstructor("R_default_Env", 2), AutoMapUtils.toStrategoTerm_Env(value, factory), AutoMapUtils.toStrategoTerm_Store(_1, factory));
+    return factory.makeAppl(factory.makeConstructor("R_default_Map_String_Int_", 2), AutoMapUtils.map_String_int2aterm(value, factory), AutoMapUtils.map_int_A_V2aterm(_1, factory));
   }
 
   public com.github.krukow.clj_ds.PersistentMap<Integer, A_V> get_1()

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/R_default_Map_String_Method_.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/R_default_Map_String_Method_.java
@@ -5,13 +5,13 @@ import org.metaborg.meta.interpreter.framework.IConvertibleToStrategoTerm;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.interpreter.terms.ITermFactory;
 
-public class R_default_C  implements IConvertibleToStrategoTerm
+public class R_default_Map_String_Method_  implements IConvertibleToStrategoTerm
 { 
-  public final com.github.krukow.clj_ds.PersistentMap<String, A_Class> value;
+  public final com.github.krukow.clj_ds.PersistentMap<String, A_Method> value;
 
   public com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _1;
 
-  public R_default_C (com.github.krukow.clj_ds.PersistentMap<String, A_Class> value, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _1) 
+  public R_default_Map_String_Method_ (com.github.krukow.clj_ds.PersistentMap<String, A_Method> value, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _1) 
   { 
     this.value = value;
     this._1 = _1;
@@ -19,7 +19,7 @@ public class R_default_C  implements IConvertibleToStrategoTerm
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)
   { 
-    return factory.makeAppl(factory.makeConstructor("R_default_C", 2), AutoMapUtils.toStrategoTerm_C(value, factory), AutoMapUtils.toStrategoTerm_Store(_1, factory));
+    return factory.makeAppl(factory.makeConstructor("R_default_Map_String_Method_", 2), AutoMapUtils.map_String_A_Method2aterm(value, factory), AutoMapUtils.map_int_A_V2aterm(_1, factory));
   }
 
   public com.github.krukow.clj_ds.PersistentMap<Integer, A_V> get_1()

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/R_default_Map_String_V_.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/R_default_Map_String_V_.java
@@ -5,13 +5,13 @@ import org.metaborg.meta.interpreter.framework.IConvertibleToStrategoTerm;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.interpreter.terms.ITermFactory;
 
-public class R_default_MM  implements IConvertibleToStrategoTerm
+public class R_default_Map_String_V_  implements IConvertibleToStrategoTerm
 { 
-  public final com.github.krukow.clj_ds.PersistentMap<String, A_Method> value;
+  public final com.github.krukow.clj_ds.PersistentMap<String, A_V> value;
 
   public com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _1;
 
-  public R_default_MM (com.github.krukow.clj_ds.PersistentMap<String, A_Method> value, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _1) 
+  public R_default_Map_String_V_ (com.github.krukow.clj_ds.PersistentMap<String, A_V> value, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _1) 
   { 
     this.value = value;
     this._1 = _1;
@@ -19,7 +19,7 @@ public class R_default_MM  implements IConvertibleToStrategoTerm
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)
   { 
-    return factory.makeAppl(factory.makeConstructor("R_default_MM", 2), AutoMapUtils.toStrategoTerm_MM(value, factory), AutoMapUtils.toStrategoTerm_Store(_1, factory));
+    return factory.makeAppl(factory.makeConstructor("R_default_Map_String_V_", 2), AutoMapUtils.map_String_A_V2aterm(value, factory), AutoMapUtils.map_int_A_V2aterm(_1, factory));
   }
 
   public com.github.krukow.clj_ds.PersistentMap<Integer, A_V> get_1()

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/R_default_Method.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/R_default_Method.java
@@ -19,7 +19,7 @@ public class R_default_Method  implements IConvertibleToStrategoTerm
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)
   { 
-    return factory.makeAppl(factory.makeConstructor("R_default_Method", 2), value.toStrategoTerm(factory), AutoMapUtils.toStrategoTerm_Store(_1, factory));
+    return factory.makeAppl(factory.makeConstructor("R_default_Method", 2), value.toStrategoTerm(factory), AutoMapUtils.map_int_A_V2aterm(_1, factory));
   }
 
   public com.github.krukow.clj_ds.PersistentMap<Integer, A_V> get_1()

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/R_default_Obj.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/R_default_Obj.java
@@ -19,7 +19,7 @@ public class R_default_Obj  implements IConvertibleToStrategoTerm
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)
   { 
-    return factory.makeAppl(factory.makeConstructor("R_default_Obj", 2), value.toStrategoTerm(factory), AutoMapUtils.toStrategoTerm_Store(_1, factory));
+    return factory.makeAppl(factory.makeConstructor("R_default_Obj", 2), value.toStrategoTerm(factory), AutoMapUtils.map_int_A_V2aterm(_1, factory));
   }
 
   public com.github.krukow.clj_ds.PersistentMap<Integer, A_V> get_1()

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/R_default_Super.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/R_default_Super.java
@@ -19,7 +19,7 @@ public class R_default_Super  implements IConvertibleToStrategoTerm
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)
   { 
-    return factory.makeAppl(factory.makeConstructor("R_default_Super", 2), value.toStrategoTerm(factory), AutoMapUtils.toStrategoTerm_Store(_1, factory));
+    return factory.makeAppl(factory.makeConstructor("R_default_Super", 2), value.toStrategoTerm(factory), AutoMapUtils.map_int_A_V2aterm(_1, factory));
   }
 
   public com.github.krukow.clj_ds.PersistentMap<Integer, A_V> get_1()

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/R_default_V.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/R_default_V.java
@@ -19,7 +19,7 @@ public class R_default_V  implements IConvertibleToStrategoTerm
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)
   { 
-    return factory.makeAppl(factory.makeConstructor("R_default_V", 2), value.toStrategoTerm(factory), AutoMapUtils.toStrategoTerm_Store(_1, factory));
+    return factory.makeAppl(factory.makeConstructor("R_default_V", 2), value.toStrategoTerm(factory), AutoMapUtils.map_int_A_V2aterm(_1, factory));
   }
 
   public com.github.krukow.clj_ds.PersistentMap<Integer, A_V> get_1()

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/R_init_V.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/R_init_V.java
@@ -1,0 +1,21 @@
+package ds.generated.interpreter;
+
+import org.metaborg.meta.interpreter.framework.*;
+import org.metaborg.meta.interpreter.framework.IConvertibleToStrategoTerm;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.interpreter.terms.ITermFactory;
+
+public class R_init_V  implements IConvertibleToStrategoTerm
+{ 
+  public final A_V value;
+
+  public R_init_V (A_V value) 
+  { 
+    this.value = value;
+  }
+
+  @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)
+  { 
+    return factory.makeAppl(factory.makeConstructor("R_init_V", 1), value.toStrategoTerm(factory));
+  }
+}

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Set_4.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Set_4.java
@@ -111,43 +111,43 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in22300 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in30300 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in30300 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in30300 = _4;
-    final A_Expr lifted_18820000 = this._1;
-    final A_Type lifted_18830000 = this._2;
-    final String f8700000 = this._3;
-    final A_Expr lifted_18840000 = this._4;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in25500 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in27700 = _2;
+    final A_This this_in24700 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in27700 = _4;
+    final A_Expr lifted_43630000 = this._1;
+    final A_Type lifted_43640000 = this._2;
+    final String f1199000000 = this._3;
+    final A_Expr lifted_43650000 = this._4;
     { 
-      final A_This this_123300 = this_in22300;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_130800 = env_in30300;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_136400 = c_in30300;
-      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_130800 = store_in30300;
-      final R_default_V $tmp622 = lifted_18820000.exec_default(this_123300, env_130800, c_136400, store_130800);
-      final A_V lifted_2079000 = $tmp622.value;
-      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_222500 = $tmp622.get_1();
-      final o2v_1 $tmp623 = lifted_2079000.match(o2v_1.class);
-      if($tmp623 != null)
+      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_126600 = l_string_class_in25500;
+      final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_128100 = l_string_v_in27700;
+      final A_This this_125500 = this_in24700;
+      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_128100 = l_int_v_in27700;
+      final R_default_V $tmp1086 = lifted_43630000.exec_default(l_string_class_126600, l_string_v_128100, this_125500, l_int_v_128100);
+      final A_V lifted_4547000 = $tmp1086.value;
+      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_221200 = $tmp1086.get_1();
+      final o2v_1 $tmp1087 = lifted_4547000.match(o2v_1.class);
+      if($tmp1087 != null)
       { 
-        final A_Obj o8700000 = $tmp623.get_1();
-        final ClassT_1 $tmp624 = lifted_18830000.match(ClassT_1.class);
-        if($tmp624 != null)
+        final A_Obj o602000000 = $tmp1087.get_1();
+        final ClassT_1 $tmp1088 = lifted_43640000.match(ClassT_1.class);
+        if($tmp1088 != null)
         { 
-          final String c16600000 = $tmp624.get_1();
-          final R_default_V $tmp625 = lifted_18840000.exec_default(this_123300, env_130800, c_136400, store_222500);
-          final A_V v15200000 = $tmp625.value;
-          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_314400 = $tmp625.get_1();
-          final writeField_4 lifted_18850000 = new writeField_4(this.getSourceInfo(), o8700000, c16600000, f8700000, v15200000);
-          final R_default_V $tmp626 = lifted_18850000.exec_default(this_123300, env_130800, c_136400, store_314400);
-          final A_V lifted_2081000 = $tmp626.value;
-          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_43200 = $tmp626.get_1();
-          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out30300 = store_43200;
-          final A_V result_out30300 = lifted_2081000;
-          return new R_default_V(result_out30300, store_out30300);
+          final String c1263000000 = $tmp1088.get_1();
+          final R_default_V $tmp1089 = lifted_43650000.exec_default(l_string_class_126600, l_string_v_128100, this_125500, l_int_v_221200);
+          final A_V v1181000000 = $tmp1089.value;
+          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_313700 = $tmp1089.get_1();
+          final writeField_4 lifted_43660000 = new writeField_4(this.getSourceInfo(), o602000000, c1263000000, f1199000000, v1181000000);
+          final R_default_V $tmp1090 = lifted_43660000.exec_default(l_string_class_126600, l_string_v_128100, this_125500, l_int_v_313700);
+          final A_V lifted_4549000 = $tmp1090.value;
+          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_42900 = $tmp1090.get_1();
+          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out27600 = l_int_v_42900;
+          final A_V result_out55400 = lifted_4549000;
+          return new R_default_V(result_out55400, l_int_v_out27600);
         }
         else
         { }
@@ -182,7 +182,7 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)
   { 
-    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("Set", 4), _1.toStrategoTerm(factory), _2.toStrategoTerm(factory), factory.makeString(_3), _4.toStrategoTerm(factory));
+    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("Set", 4), _1.toStrategoTerm(factory), _2.toStrategoTerm(factory), TermUtils.termFromString(_3, factory), _4.toStrategoTerm(factory));
     if(getSourceInfo() != null)
     { 
       getSourceInfo().apply(term);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Sub_2.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Sub_2.java
@@ -77,39 +77,39 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in20500 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in28600 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in28600 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in28600 = _4;
-    final A_Expr lifted_18780000 = this._1;
-    final A_Expr lifted_18790000 = this._2;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in24000 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in26200 = _2;
+    final A_This this_in22900 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in26200 = _4;
+    final A_Expr lifted_43590000 = this._1;
+    final A_Expr lifted_43600000 = this._2;
     { 
-      final A_This this_121600 = this_in20500;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_129200 = env_in28600;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_134200 = c_in28600;
-      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_129200 = store_in28600;
-      final R_default_V $tmp579 = lifted_18780000.exec_default(this_121600, env_129200, c_134200, store_129200);
-      final A_V lifted_2077000 = $tmp579.value;
-      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_220800 = $tmp579.get_1();
-      final NumV_1 $tmp580 = lifted_2077000.match(NumV_1.class);
-      if($tmp580 != null)
+      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_125100 = l_string_class_in24000;
+      final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_126600 = l_string_v_in26200;
+      final A_This this_123800 = this_in22900;
+      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_126600 = l_int_v_in26200;
+      final R_default_V $tmp1043 = lifted_43590000.exec_default(l_string_class_125100, l_string_v_126600, this_123800, l_int_v_126600);
+      final A_V lifted_4545000 = $tmp1043.value;
+      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_219700 = $tmp1043.get_1();
+      final NumV_1 $tmp1044 = lifted_4545000.match(NumV_1.class);
+      if($tmp1044 != null)
       { 
-        final int i6300000 = $tmp580.get_1();
-        final R_default_V $tmp581 = lifted_18790000.exec_default(this_121600, env_129200, c_134200, store_220800);
-        final A_V lifted_2076000 = $tmp581.value;
-        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_313200 = $tmp581.get_1();
-        final NumV_1 $tmp582 = lifted_2076000.match(NumV_1.class);
-        if($tmp582 != null)
+        final int i507000000 = $tmp1044.get_1();
+        final R_default_V $tmp1045 = lifted_43600000.exec_default(l_string_class_125100, l_string_v_126600, this_123800, l_int_v_219700);
+        final A_V lifted_4544000 = $tmp1045.value;
+        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_312400 = $tmp1045.get_1();
+        final NumV_1 $tmp1046 = lifted_4544000.match(NumV_1.class);
+        if($tmp1046 != null)
         { 
-          final int j4200000 = $tmp582.get_1();
-          final int lifted_18810000 = ds.manual.interpreter.Natives.minusI_2(i6300000, j4200000);
-          final NumV_1 lifted_18800000 = new NumV_1(this.getSourceInfo(), lifted_18810000);
-          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out28600 = store_313200;
-          final A_V result_out28600 = lifted_18800000;
-          return new R_default_V(result_out28600, store_out28600);
+          final int j261000000 = $tmp1046.get_1();
+          final int lifted_43620000 = ds.manual.interpreter.Natives.minusI_2(i507000000, j261000000);
+          final NumV_1 lifted_43610000 = new NumV_1(this.getSourceInfo(), lifted_43620000);
+          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out26100 = l_int_v_312400;
+          final A_V result_out53900 = lifted_43610000;
+          return new R_default_V(result_out53900, l_int_v_out26100);
         }
         else
         { }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/This_0.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/This_0.java
@@ -39,26 +39,26 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in22600 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in30600 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in30600 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in30600 = _4;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in25800 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in28000 = _2;
+    final A_This this_in25100 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in28000 = _4;
     { 
-      final A_This lifted_18770000 = this_in22600;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_131300 = env_in30600;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_137300 = c_in30600;
-      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_131300 = store_in30600;
-      final T_1 $tmp637 = lifted_18770000.match(T_1.class);
-      if($tmp637 != null)
+      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_126900 = l_string_class_in25800;
+      final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_128400 = l_string_v_in28000;
+      final A_This lifted_43580000 = this_in25100;
+      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_128400 = l_int_v_in28000;
+      final T_1 $tmp1101 = lifted_43580000.match(T_1.class);
+      if($tmp1101 != null)
       { 
-        final A_Obj o8600000 = $tmp637.get_1();
-        final o2v_1 lifted_2074000 = new o2v_1(this.getSourceInfo(), o8600000);
-        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out30600 = store_131300;
-        final A_V result_out30600 = lifted_2074000;
-        return new R_default_V(result_out30600, store_out30600);
+        final A_Obj o601000000 = $tmp1101.get_1();
+        final o2v_1 lifted_4542000 = new o2v_1(this.getSourceInfo(), o601000000);
+        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out27900 = l_int_v_128400;
+        final A_V result_out55700 = lifted_4542000;
+        return new R_default_V(result_out55700, l_int_v_out27900);
       }
       else
       { }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/True_0.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/True_0.java
@@ -39,22 +39,22 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in20700 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in28800 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in28800 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in28800 = _4;
-    final A_This this_121800 = this_in20700;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_129400 = env_in28800;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_134400 = c_in28800;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_129400 = store_in28800;
-    final boolean lifted_18760000 = true;
-    final BoolV_1 lifted_18750000 = new BoolV_1(this.getSourceInfo(), lifted_18760000);
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out28800 = store_129400;
-    final A_V result_out28800 = lifted_18750000;
-    return new R_default_V(result_out28800, store_out28800);
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in24200 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in26400 = _2;
+    final A_This this_in23300 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in26400 = _4;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_125300 = l_string_class_in24200;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_126800 = l_string_v_in26400;
+    final A_This this_124100 = this_in23300;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_126800 = l_int_v_in26400;
+    final boolean lifted_43570000 = true;
+    final BoolV_1 lifted_43560000 = new BoolV_1(this.getSourceInfo(), lifted_43570000);
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out26300 = l_int_v_126800;
+    final A_V result_out54100 = lifted_43560000;
+    return new R_default_V(result_out54100, l_int_v_out26300);
   }
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Var_1.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/Var_1.java
@@ -54,25 +54,25 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in21900 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in29900 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in29900 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in29900 = _4;
-    final String x51100000 = this._1;
-    final A_This this_122900 = this_in21900;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_130500 = env_in29900;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_136100 = c_in29900;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_130500 = store_in29900;
-    final readVar_1 lifted_18740000 = new readVar_1(this.getSourceInfo(), x51100000);
-    final R_default_V $tmp612 = lifted_18740000.exec_default(this_122900, env_130500, c_136100, store_130500);
-    final A_V lifted_2071000 = $tmp612.value;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_222100 = $tmp612.get_1();
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out29900 = store_222100;
-    final A_V result_out29900 = lifted_2071000;
-    return new R_default_V(result_out29900, store_out29900);
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in25200 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in27400 = _2;
+    final A_This this_in24400 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in27400 = _4;
+    final String x592000000 = this._1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_126300 = l_string_class_in25200;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_127800 = l_string_v_in27400;
+    final A_This this_125200 = this_in24400;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_127800 = l_int_v_in27400;
+    final readVar_1 lifted_43550000 = new readVar_1(this.getSourceInfo(), x592000000);
+    final R_default_V $tmp1076 = lifted_43550000.exec_default(l_string_class_126300, l_string_v_127800, this_125200, l_int_v_127800);
+    final A_V lifted_4539000 = $tmp1076.value;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_220700 = $tmp1076.get_1();
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out27300 = l_int_v_220700;
+    final A_V result_out55100 = lifted_4539000;
+    return new R_default_V(result_out55100, l_int_v_out27300);
   }
 
   public String get_1()
@@ -82,7 +82,7 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)
   { 
-    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("Var", 1), factory.makeString(_1));
+    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("Var", 1), TermUtils.termFromString(_1, factory));
     if(getSourceInfo() != null)
     { 
       getSourceInfo().apply(term);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/allocate_1.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/allocate_1.java
@@ -58,26 +58,26 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_Int exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_Int exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in23200 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in31300 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in31300 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in31300 = _4;
-    final A_V v16200000 = this._1;
-    final A_This this_124100 = this_in23200;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_131600 = env_in31300;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_137800 = c_in31300;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_131800 = store_in31300;
-    final int loc4600000 = ds.manual.interpreter.Natives.fresh();
-    final write_2 lifted_20510000 = new write_2(this.getSourceInfo(), loc4600000, v16200000);
-    final R_default_V $tmp639 = lifted_20510000.exec_default(this_124100, env_131600, c_137800, store_131800);
-    final A_V lifted_18650000 = $tmp639.value;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_222900 = $tmp639.get_1();
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out31300 = store_222900;
-    final int result_out31300 = loc4600000;
-    return new R_default_Int(result_out31300, store_out31300);
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in26300 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in28500 = _2;
+    final A_This this_in25600 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in28500 = _4;
+    final A_V v1190000000 = this._1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_127400 = l_string_class_in26300;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_128700 = l_string_v_in28500;
+    final A_This this_126300 = this_in25600;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_128900 = l_int_v_in28500;
+    final int loc42100000 = ds.manual.interpreter.Natives.fresh();
+    final write_2 lifted_45200000 = new write_2(this.getSourceInfo(), loc42100000, v1190000000);
+    final R_default_V $tmp1103 = lifted_45200000.exec_default(l_string_class_127400, l_string_v_128700, this_126300, l_int_v_128900);
+    final A_V lifted_43460000 = $tmp1103.value;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_221600 = $tmp1103.get_1();
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out28400 = l_int_v_221600;
+    final int result_out56200 = loc42100000;
+    return new R_default_Int(result_out56200, l_int_v_out28400);
   }
 
   public A_V get_1()

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/bindVar_2.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/bindVar_2.java
@@ -73,23 +73,24 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_Env exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_Map_String_V_ exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in22800 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in30800 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in30800 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in30800 = _4;
-    final String x51500000 = this._1;
-    final A_V v16100000 = this._2;
-    final A_This this_123700 = this_in22800;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> E4600000 = env_in30800;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_137500 = c_in30800;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_131500 = store_in30800;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> lifted_20420000 = MapUtils.plus(E4600000, new com.github.krukow.clj_lang.PersistentTreeMap<String, A_V>().plus(x51500000, v16100000));
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out30800 = store_131500;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> result_out30800 = lifted_20420000;
-    return new R_default_Env(result_out30800, store_out30800);
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in26000 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in28200 = _2;
+    final A_This this_in25300 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in28200 = _4;
+    final String x596000000 = this._1;
+    final A_V v1189000000 = this._2;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_127100 = l_string_class_in26000;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> E48000000 = l_string_v_in28200;
+    final A_This this_125900 = this_in25300;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_128600 = l_int_v_in28200;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> lifted_45120000 = new com.github.krukow.clj_lang.PersistentTreeMap<String, A_V>().plus(x596000000, v1189000000);
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> lifted_45110000 = MapUtils.plus(E48000000, lifted_45120000);
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out28100 = l_int_v_128600;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> result_out55900 = lifted_45110000;
+    return new R_default_Map_String_V_(result_out55900, l_int_v_out28100);
   }
 
   public String get_1()
@@ -104,7 +105,7 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)
   { 
-    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("bindVar", 2), factory.makeString(_1), _2.toStrategoTerm(factory));
+    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("bindVar", 2), TermUtils.termFromString(_1, factory), _2.toStrategoTerm(factory));
     if(getSourceInfo() != null)
     { 
       getSourceInfo().apply(term);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/bindVars_2.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/bindVars_2.java
@@ -81,51 +81,52 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_Env exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_Map_String_V_ exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in23100 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in31200 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in31200 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in31200 = _4;
-    final L_String lifted_20340000 = this._1;
-    final L_A_V lifted_20350000 = this._2;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in26200 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in28400 = _2;
+    final A_This this_in25500 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in28400 = _4;
+    final L_String lifted_45030000 = this._1;
+    final L_A_V lifted_45040000 = this._2;
     { 
-      final A_This this_123900 = this_in23100;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_131500 = env_in31200;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_137700 = c_in31200;
-      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_131700 = store_in31200;
-      if(lifted_20340000 != null && lifted_20340000.equals(new NIL(this.getSourceInfo())))
+      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_127300 = l_string_class_in26200;
+      final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_128600 = l_string_v_in28400;
+      final A_This this_126200 = this_in25500;
+      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_128800 = l_int_v_in28400;
+      if(lifted_45030000 != null && lifted_45030000.equals(new NIL(this.getSourceInfo())))
       { 
-        if(lifted_20350000 != null && lifted_20350000.equals(new NIL(this.getSourceInfo())))
+        if(lifted_45040000 != null && lifted_45040000.equals(new NIL(this.getSourceInfo())))
         { 
-          final com.github.krukow.clj_ds.PersistentMap<?, ?> lifted_20330000 = (com.github.krukow.clj_ds.PersistentMap<?, ?>)PersistentTreeMap.EMPTY;
-          final com.github.krukow.clj_ds.PersistentMap<String, A_V> lifted_20320000 = (com.github.krukow.clj_ds.PersistentMap<String, A_V>)lifted_20330000;
-          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out31200 = store_131700;
-          final com.github.krukow.clj_ds.PersistentMap<String, A_V> result_out31200 = lifted_20320000;
-          return new R_default_Env(result_out31200, store_out31200);
+          final com.github.krukow.clj_ds.PersistentMap<?, ?> lifted_45020000 = (com.github.krukow.clj_ds.PersistentMap<?, ?>)PersistentTreeMap.EMPTY;
+          final com.github.krukow.clj_ds.PersistentMap<String, A_V> lifted_45010000 = (com.github.krukow.clj_ds.PersistentMap<String, A_V>)lifted_45020000;
+          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out28300 = l_int_v_128800;
+          final com.github.krukow.clj_ds.PersistentMap<String, A_V> result_out56100 = lifted_45010000;
+          return new R_default_Map_String_V_(result_out56100, l_int_v_out28300);
         }
         else
         { }
       }
       else
       { 
-        if(lifted_20340000 != null && !lifted_20340000.isEmpty())
+        if(lifted_45030000 != null && !lifted_45030000.isEmpty())
         { 
-          final String x51400000 = lifted_20340000.head();
-          final L_String xs2900000 = lifted_20340000.tail();
-          if(lifted_20350000 != null && !lifted_20350000.isEmpty())
+          final String x595000000 = lifted_45030000.head();
+          final L_String xs187000000 = lifted_45030000.tail();
+          if(lifted_45040000 != null && !lifted_45040000.isEmpty())
           { 
-            final A_V v15900000 = lifted_20350000.head();
-            final L_A_V vs2900000 = lifted_20350000.tail();
-            final bindVars_2 lifted_20380000 = new bindVars_2(this.getSourceInfo(), xs2900000, vs2900000);
-            final R_default_Env $tmp638 = lifted_20380000.exec_default(this_123900, env_131500, c_137700, store_131700);
-            final com.github.krukow.clj_ds.PersistentMap<String, A_V> E4500000 = $tmp638.value;
-            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_222800 = $tmp638.get_1();
-            final com.github.krukow.clj_ds.PersistentMap<String, A_V> lifted_20360000 = MapUtils.plus(E4500000, new com.github.krukow.clj_lang.PersistentTreeMap<String, A_V>().plus(x51400000, v15900000));
-            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out31200 = store_222800;
-            final com.github.krukow.clj_ds.PersistentMap<String, A_V> result_out31200 = lifted_20360000;
-            return new R_default_Env(result_out31200, store_out31200);
+            final A_V v1188000000 = lifted_45040000.head();
+            final L_A_V vs150000000 = lifted_45040000.tail();
+            final bindVars_2 lifted_45070000 = new bindVars_2(this.getSourceInfo(), xs187000000, vs150000000);
+            final R_default_Map_String_V_ $tmp1102 = lifted_45070000.exec_default(l_string_class_127300, l_string_v_128600, this_126200, l_int_v_128800);
+            final com.github.krukow.clj_ds.PersistentMap<String, A_V> E47000000 = $tmp1102.value;
+            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_221500 = $tmp1102.get_1();
+            final com.github.krukow.clj_ds.PersistentMap<String, A_V> lifted_45090000 = new com.github.krukow.clj_lang.PersistentTreeMap<String, A_V>().plus(x595000000, v1188000000);
+            final com.github.krukow.clj_ds.PersistentMap<String, A_V> lifted_45050000 = MapUtils.plus(E47000000, lifted_45090000);
+            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out28300 = l_int_v_221500;
+            final com.github.krukow.clj_ds.PersistentMap<String, A_V> result_out56100 = lifted_45050000;
+            return new R_default_Map_String_V_(result_out56100, l_int_v_out28300);
           }
           else
           { }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/block2expr_1.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/block2expr_1.java
@@ -58,64 +58,64 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in21800 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in29800 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in29800 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in29800 = _4;
-    final A_Block lifted_2153000 = this._1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in25100 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in27300 = _2;
+    final A_This this_in24300 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in27300 = _4;
+    final A_Block lifted_4616000 = this._1;
     { 
-      final A_This this_122800 = this_in21800;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_130400 = env_in29800;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_135900 = c_in29800;
-      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_130400 = store_in29800;
-      final Do_1 $tmp608 = lifted_2153000.match(Do_1.class);
-      if($tmp608 != null)
+      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_126200 = l_string_class_in25100;
+      final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_127700 = l_string_v_in27300;
+      final A_This this_125100 = this_in24300;
+      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_127700 = l_int_v_in27300;
+      final Do_1 $tmp1072 = lifted_4616000.match(Do_1.class);
+      if($tmp1072 != null)
       { 
-        final L_A_Seq lifted_20090000 = $tmp608.get_1();
-        if(lifted_20090000 != null && lifted_20090000.equals(new NIL(this.getSourceInfo())))
+        final L_A_Seq lifted_44810000 = $tmp1072.get_1();
+        if(lifted_44810000 != null && lifted_44810000.equals(new NIL(this.getSourceInfo())))
         { 
-          final U_0 lifted_20050000 = new U_0(this.getSourceInfo());
-          final u2v_1 lifted_2148000 = new u2v_1(this.getSourceInfo(), lifted_20050000);
-          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out29800 = store_130400;
-          final A_V result_out29800 = lifted_2148000;
-          return new R_default_V(result_out29800, store_out29800);
+          final U_0 lifted_44770000 = new U_0(this.getSourceInfo());
+          final u2v_1 lifted_4611000 = new u2v_1(this.getSourceInfo(), lifted_44770000);
+          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out27200 = l_int_v_127700;
+          final A_V result_out55000 = lifted_4611000;
+          return new R_default_V(result_out55000, l_int_v_out27200);
         }
         else
         { 
-          if(lifted_20090000 != null && !lifted_20090000.isEmpty())
+          if(lifted_44810000 != null && !lifted_44810000.isEmpty())
           { 
-            final A_Seq lifted_20120000 = lifted_20090000.head();
-            final L_A_Seq stats700000 = lifted_20090000.tail();
-            final expr2seq_1 $tmp609 = lifted_20120000.match(expr2seq_1.class);
-            if($tmp609 != null)
+            final A_Seq lifted_44830000 = lifted_44810000.head();
+            final L_A_Seq stats61000000 = lifted_44810000.tail();
+            final expr2seq_1 $tmp1073 = lifted_44830000.match(expr2seq_1.class);
+            if($tmp1073 != null)
             { 
-              final A_Expr lifted_2154000 = $tmp609.get_1();
-              final R_default_V $tmp610 = lifted_2154000.exec_default(this_122800, env_130400, c_135900, store_130400);
-              final A_V v15800000 = $tmp610.value;
-              final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_221900 = $tmp610.get_1();
-              if(stats700000 != null && stats700000.equals(new NIL(this.getSourceInfo())))
+              final A_Expr lifted_4617000 = $tmp1073.get_1();
+              final R_default_V $tmp1074 = lifted_4617000.exec_default(l_string_class_126200, l_string_v_127700, this_125100, l_int_v_127700);
+              final A_V v1187000000 = $tmp1074.value;
+              final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_220600 = $tmp1074.get_1();
+              if(stats61000000 != null && stats61000000.equals(new NIL(this.getSourceInfo())))
               { 
-                final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out29800 = store_221900;
-                final A_V result_out29800 = v15800000;
-                return new R_default_V(result_out29800, store_out29800);
+                final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out27200 = l_int_v_220600;
+                final A_V result_out55000 = v1187000000;
+                return new R_default_V(result_out55000, l_int_v_out27200);
               }
               else
               { 
-                if(stats700000 != null && !stats700000.isEmpty())
+                if(stats61000000 != null && !stats61000000.isEmpty())
                 { 
-                  final A_Seq lifted_18580000 = stats700000.head();
-                  final L_A_Seq lifted_18590000 = stats700000.tail();
-                  final Do_1 lifted_20110000 = new Do_1(this.getSourceInfo(), stats700000);
-                  final block2expr_1 lifted_2157000 = new block2expr_1(this.getSourceInfo(), lifted_20110000);
-                  final R_default_V $tmp611 = lifted_2157000.exec_default(this_122800, env_130400, c_135900, store_221900);
-                  final A_V lifted_2156000 = $tmp611.value;
-                  final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_314100 = $tmp611.get_1();
-                  final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out29800 = store_314100;
-                  final A_V result_out29800 = lifted_2156000;
-                  return new R_default_V(result_out29800, store_out29800);
+                  final A_Seq lifted_43400000 = stats61000000.head();
+                  final L_A_Seq lifted_43410000 = stats61000000.tail();
+                  final Do_1 lifted_44820000 = new Do_1(this.getSourceInfo(), stats61000000);
+                  final block2expr_1 lifted_4620000 = new block2expr_1(this.getSourceInfo(), lifted_44820000);
+                  final R_default_V $tmp1075 = lifted_4620000.exec_default(l_string_class_126200, l_string_v_127700, this_125100, l_int_v_220600);
+                  final A_V lifted_4619000 = $tmp1075.value;
+                  final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_313400 = $tmp1075.get_1();
+                  final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out27200 = l_int_v_313400;
+                  final A_V result_out55000 = lifted_4619000;
+                  return new R_default_V(result_out55000, l_int_v_out27200);
                 }
                 else
                 { }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/defaultValue_1.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/defaultValue_1.java
@@ -58,49 +58,49 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in19500 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in27600 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in27600 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in27600 = _4;
-    final A_Type lifted_20210000 = this._1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in23100 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in25300 = _2;
+    final A_This this_in21800 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in25300 = _4;
+    final A_Type lifted_44910000 = this._1;
     { 
-      final A_This this_120400 = this_in19500;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_128100 = env_in27600;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_132900 = c_in27600;
-      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_128100 = store_in27600;
-      final NumT_0 $tmp557 = lifted_20210000.match(NumT_0.class);
-      if($tmp557 != null)
+      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_124100 = l_string_class_in23100;
+      final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_125600 = l_string_v_in25300;
+      final A_This this_122700 = this_in21800;
+      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_125600 = l_int_v_in25300;
+      final NumT_0 $tmp1021 = lifted_44910000.match(NumT_0.class);
+      if($tmp1021 != null)
       { 
-        final int lifted_20160000 = 0;
-        final NumV_1 lifted_20150000 = new NumV_1(this.getSourceInfo(), lifted_20160000);
-        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out27600 = store_128100;
-        final A_V result_out27600 = lifted_20150000;
-        return new R_default_V(result_out27600, store_out27600);
+        final int lifted_44870000 = 0;
+        final NumV_1 lifted_44860000 = new NumV_1(this.getSourceInfo(), lifted_44870000);
+        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out25200 = l_int_v_125600;
+        final A_V result_out53000 = lifted_44860000;
+        return new R_default_V(result_out53000, l_int_v_out25200);
       }
       else
       { 
-        final BoolT_0 $tmp558 = lifted_20210000.match(BoolT_0.class);
-        if($tmp558 != null)
+        final BoolT_0 $tmp1022 = lifted_44910000.match(BoolT_0.class);
+        if($tmp1022 != null)
         { 
-          final boolean lifted_20190000 = false;
-          final BoolV_1 lifted_20180000 = new BoolV_1(this.getSourceInfo(), lifted_20190000);
-          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out27600 = store_128100;
-          final A_V result_out27600 = lifted_20180000;
-          return new R_default_V(result_out27600, store_out27600);
+          final boolean lifted_44900000 = false;
+          final BoolV_1 lifted_44890000 = new BoolV_1(this.getSourceInfo(), lifted_44900000);
+          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out25200 = l_int_v_125600;
+          final A_V result_out53000 = lifted_44890000;
+          return new R_default_V(result_out53000, l_int_v_out25200);
         }
         else
         { 
-          final ClassT_1 $tmp559 = lifted_20210000.match(ClassT_1.class);
-          if($tmp559 != null)
+          final ClassT_1 $tmp1023 = lifted_44910000.match(ClassT_1.class);
+          if($tmp1023 != null)
           { 
-            final String lifted_18610000 = $tmp559.get_1();
-            final NullV_0 lifted_20220000 = new NullV_0(this.getSourceInfo());
-            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out27600 = store_128100;
-            final A_V result_out27600 = lifted_20220000;
-            return new R_default_V(result_out27600, store_out27600);
+            final String lifted_43420000 = $tmp1023.get_1();
+            final NullV_0 lifted_44920000 = new NullV_0(this.getSourceInfo());
+            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out25200 = l_int_v_125600;
+            final A_V result_out53000 = lifted_44920000;
+            return new R_default_V(result_out53000, l_int_v_out25200);
           }
           else
           { }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/initClasses_1.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/initClasses_1.java
@@ -66,48 +66,49 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_C exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_Map_String_Class_ exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in18900 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in27100 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in27100 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in27100 = _4;
-    final L_A_Class lifted_19850000 = this._1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in22600 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in24800 = _2;
+    final A_This this_in20900 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in24800 = _4;
+    final L_A_Class lifted_44580000 = this._1;
     { 
-      final A_This this_119800 = this_in18900;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_127500 = env_in27100;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_132300 = c_in27100;
-      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_127500 = store_in27100;
-      if(lifted_19850000 != null && lifted_19850000.equals(new NIL(this.getSourceInfo())))
+      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_123600 = l_string_class_in22600;
+      final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_125100 = l_string_v_in24800;
+      final A_This this_122200 = this_in20900;
+      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_125100 = l_int_v_in24800;
+      if(lifted_44580000 != null && lifted_44580000.equals(new NIL(this.getSourceInfo())))
       { 
-        final com.github.krukow.clj_ds.PersistentMap<?, ?> lifted_19840000 = (com.github.krukow.clj_ds.PersistentMap<?, ?>)PersistentTreeMap.EMPTY;
-        final com.github.krukow.clj_ds.PersistentMap<String, A_Class> lifted_19830000 = (com.github.krukow.clj_ds.PersistentMap<String, A_Class>)lifted_19840000;
-        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out27100 = store_127500;
-        final com.github.krukow.clj_ds.PersistentMap<String, A_Class> result_out27100 = lifted_19830000;
-        return new R_default_C(result_out27100, store_out27100);
+        final com.github.krukow.clj_ds.PersistentMap<?, ?> lifted_44570000 = (com.github.krukow.clj_ds.PersistentMap<?, ?>)PersistentTreeMap.EMPTY;
+        final com.github.krukow.clj_ds.PersistentMap<String, A_Class> lifted_44560000 = (com.github.krukow.clj_ds.PersistentMap<String, A_Class>)lifted_44570000;
+        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out24700 = l_int_v_125100;
+        final com.github.krukow.clj_ds.PersistentMap<String, A_Class> result_out52500 = lifted_44560000;
+        return new R_default_Map_String_Class_(result_out52500, l_int_v_out24700);
       }
       else
       { 
-        if(lifted_19850000 != null && !lifted_19850000.isEmpty())
+        if(lifted_44580000 != null && !lifted_44580000.isEmpty())
         { 
-          final A_Class c17700000 = lifted_19850000.head();
-          final L_A_Class cs3100000 = lifted_19850000.tail();
-          final Class_4 $tmp541 = c17700000.match(Class_4.class);
-          if($tmp541 != null)
+          final A_Class c1274000000 = lifted_44580000.head();
+          final L_A_Class cs321000000 = lifted_44580000.tail();
+          final Class_4 $tmp1005 = c1274000000.match(Class_4.class);
+          if($tmp1005 != null)
           { 
-            final String name4600000 = $tmp541.get_1();
-            final A_Extends lifted_18530000 = $tmp541.get_2();
-            final L_A_Field lifted_18540000 = $tmp541.get_3();
-            final L_A_Method lifted_18550000 = $tmp541.get_4();
-            final initClasses_1 lifted_19880000 = new initClasses_1(this.getSourceInfo(), cs3100000);
-            final R_default_C $tmp542 = lifted_19880000.exec_default(this_119800, env_127500, c_132300, store_127500);
-            final com.github.krukow.clj_ds.PersistentMap<String, A_Class> lifted_2132000 = $tmp542.value;
-            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_219500 = $tmp542.get_1();
-            final com.github.krukow.clj_ds.PersistentMap<String, A_Class> lifted_19860000 = MapUtils.plus(lifted_2132000, new com.github.krukow.clj_lang.PersistentTreeMap<String, A_Class>().plus(name4600000, c17700000));
-            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out27100 = store_219500;
-            final com.github.krukow.clj_ds.PersistentMap<String, A_Class> result_out27100 = lifted_19860000;
-            return new R_default_C(result_out27100, store_out27100);
+            final String name514000000 = $tmp1005.get_1();
+            final A_Extends lifted_43350000 = $tmp1005.get_2();
+            final L_A_Field lifted_43360000 = $tmp1005.get_3();
+            final L_A_Method lifted_43370000 = $tmp1005.get_4();
+            final com.github.krukow.clj_ds.PersistentMap<String, A_Class> lifted_44610000 = new com.github.krukow.clj_lang.PersistentTreeMap<String, A_Class>().plus(name514000000, c1274000000);
+            final initClasses_1 lifted_44620000 = new initClasses_1(this.getSourceInfo(), cs321000000);
+            final R_default_Map_String_Class_ $tmp1006 = lifted_44620000.exec_default(l_string_class_123600, l_string_v_125100, this_122200, l_int_v_125100);
+            final com.github.krukow.clj_ds.PersistentMap<String, A_Class> lifted_4596000 = $tmp1006.value;
+            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_218500 = $tmp1006.get_1();
+            final com.github.krukow.clj_ds.PersistentMap<String, A_Class> lifted_44590000 = MapUtils.plus(lifted_4596000, lifted_44610000);
+            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out24700 = l_int_v_218500;
+            final com.github.krukow.clj_ds.PersistentMap<String, A_Class> result_out52500 = lifted_44590000;
+            return new R_default_Map_String_Class_(result_out52500, l_int_v_out24700);
           }
           else
           { }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/initFields_1.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/initFields_1.java
@@ -66,54 +66,55 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_FM exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_Map_String_Int_ exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in19300 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in27400 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in27400 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in27400 = _4;
-    final L_A_Field lifted_19740000 = this._1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in22900 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in25100 = _2;
+    final A_This this_in21600 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in25100 = _4;
+    final L_A_Field lifted_44460000 = this._1;
     { 
-      final A_This this_120200 = this_in19300;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_127800 = env_in27400;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_132600 = c_in27400;
-      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_127800 = store_in27400;
-      if(lifted_19740000 != null && lifted_19740000.equals(new NIL(this.getSourceInfo())))
+      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_123900 = l_string_class_in22900;
+      final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_125400 = l_string_v_in25100;
+      final A_This this_122500 = this_in21600;
+      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_125400 = l_int_v_in25100;
+      if(lifted_44460000 != null && lifted_44460000.equals(new NIL(this.getSourceInfo())))
       { 
-        final com.github.krukow.clj_ds.PersistentMap<?, ?> lifted_19730000 = (com.github.krukow.clj_ds.PersistentMap<?, ?>)PersistentTreeMap.EMPTY;
-        final com.github.krukow.clj_ds.PersistentMap<String, Integer> lifted_19720000 = (com.github.krukow.clj_ds.PersistentMap<String, Integer>)lifted_19730000;
-        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out27400 = store_127800;
-        final com.github.krukow.clj_ds.PersistentMap<String, Integer> result_out27400 = lifted_19720000;
-        return new R_default_FM(result_out27400, store_out27400);
+        final com.github.krukow.clj_ds.PersistentMap<?, ?> lifted_44450000 = (com.github.krukow.clj_ds.PersistentMap<?, ?>)PersistentTreeMap.EMPTY;
+        final com.github.krukow.clj_ds.PersistentMap<String, Integer> lifted_44440000 = (com.github.krukow.clj_ds.PersistentMap<String, Integer>)lifted_44450000;
+        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out25000 = l_int_v_125400;
+        final com.github.krukow.clj_ds.PersistentMap<String, Integer> result_out52800 = lifted_44440000;
+        return new R_default_Map_String_Int_(result_out52800, l_int_v_out25000);
       }
       else
       { 
-        if(lifted_19740000 != null && !lifted_19740000.isEmpty())
+        if(lifted_44460000 != null && !lifted_44460000.isEmpty())
         { 
-          final A_Field lifted_19760000 = lifted_19740000.head();
-          final L_A_Field fs6200000 = lifted_19740000.tail();
-          final Field_2 $tmp551 = lifted_19760000.match(Field_2.class);
-          if($tmp551 != null)
+          final A_Field lifted_44480000 = lifted_44460000.head();
+          final L_A_Field fs227000000 = lifted_44460000.tail();
+          final Field_2 $tmp1015 = lifted_44480000.match(Field_2.class);
+          if($tmp1015 != null)
           { 
-            final A_Type t1600000 = $tmp551.get_1();
-            final String f9200000 = $tmp551.get_2();
-            final defaultValue_1 lifted_19770000 = new defaultValue_1(this.getSourceInfo(), t1600000);
-            final R_default_V $tmp552 = lifted_19770000.exec_default(this_120200, env_127800, c_132600, store_127800);
-            final A_V v15600000 = $tmp552.value;
-            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_219800 = $tmp552.get_1();
-            final initFields_1 lifted_19790000 = new initFields_1(this.getSourceInfo(), fs6200000);
-            final R_default_FM $tmp553 = lifted_19790000.exec_default(this_120200, env_127800, c_132600, store_219800);
-            final com.github.krukow.clj_ds.PersistentMap<String, Integer> FM1500000 = $tmp553.value;
-            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_312600 = $tmp553.get_1();
-            final allocate_1 lifted_2179000 = new allocate_1(this.getSourceInfo(), v15600000);
-            final R_default_Int $tmp554 = lifted_2179000.exec_default(this_120200, env_127800, c_132600, store_312600);
-            final int lifted_2130000 = $tmp554.value;
-            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_42900 = $tmp554.get_1();
-            final com.github.krukow.clj_ds.PersistentMap<String, Integer> lifted_19750000 = MapUtils.plus(FM1500000, new com.github.krukow.clj_lang.PersistentTreeMap<String, Integer>().plus(f9200000, lifted_2130000));
-            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out27400 = store_42900;
-            final com.github.krukow.clj_ds.PersistentMap<String, Integer> result_out27400 = lifted_19750000;
-            return new R_default_FM(result_out27400, store_out27400);
+            final A_Type t1271000000 = $tmp1015.get_1();
+            final String f1203000000 = $tmp1015.get_2();
+            final defaultValue_1 lifted_44490000 = new defaultValue_1(this.getSourceInfo(), t1271000000);
+            final R_default_V $tmp1016 = lifted_44490000.exec_default(l_string_class_123900, l_string_v_125400, this_122500, l_int_v_125400);
+            final A_V v1185000000 = $tmp1016.value;
+            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_218800 = $tmp1016.get_1();
+            final initFields_1 lifted_44510000 = new initFields_1(this.getSourceInfo(), fs227000000);
+            final R_default_Map_String_Int_ $tmp1017 = lifted_44510000.exec_default(l_string_class_123900, l_string_v_125400, this_122500, l_int_v_218800);
+            final com.github.krukow.clj_ds.PersistentMap<String, Integer> FM56000000 = $tmp1017.value;
+            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_311700 = $tmp1017.get_1();
+            final allocate_1 lifted_44530000 = new allocate_1(this.getSourceInfo(), v1185000000);
+            final R_default_Int $tmp1018 = lifted_44530000.exec_default(l_string_class_123900, l_string_v_125400, this_122500, l_int_v_311700);
+            final int addr39000000 = $tmp1018.value;
+            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_42700 = $tmp1018.get_1();
+            final com.github.krukow.clj_ds.PersistentMap<String, Integer> lifted_44540000 = new com.github.krukow.clj_lang.PersistentTreeMap<String, Integer>().plus(f1203000000, addr39000000);
+            final com.github.krukow.clj_ds.PersistentMap<String, Integer> lifted_44470000 = MapUtils.plus(FM56000000, lifted_44540000);
+            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out25000 = l_int_v_42700;
+            final com.github.krukow.clj_ds.PersistentMap<String, Integer> result_out52800 = lifted_44470000;
+            return new R_default_Map_String_Int_(result_out52800, l_int_v_out25000);
           }
           else
           { }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/initMethods_1.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/initMethods_1.java
@@ -66,48 +66,49 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_MM exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_Map_String_Method_ exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in19400 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in27500 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in27500 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in27500 = _4;
-    final L_A_Method lifted_19660000 = this._1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in23000 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in25200 = _2;
+    final A_This this_in21700 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in25200 = _4;
+    final L_A_Method lifted_44380000 = this._1;
     { 
-      final A_This this_120300 = this_in19400;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_127900 = env_in27500;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_132800 = c_in27500;
-      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_127900 = store_in27500;
-      if(lifted_19660000 != null && lifted_19660000.equals(new NIL(this.getSourceInfo())))
+      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_124000 = l_string_class_in23000;
+      final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_125500 = l_string_v_in25200;
+      final A_This this_122600 = this_in21700;
+      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_125500 = l_int_v_in25200;
+      if(lifted_44380000 != null && lifted_44380000.equals(new NIL(this.getSourceInfo())))
       { 
-        final com.github.krukow.clj_ds.PersistentMap<?, ?> lifted_19650000 = (com.github.krukow.clj_ds.PersistentMap<?, ?>)PersistentTreeMap.EMPTY;
-        final com.github.krukow.clj_ds.PersistentMap<String, A_Method> lifted_19640000 = (com.github.krukow.clj_ds.PersistentMap<String, A_Method>)lifted_19650000;
-        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out27500 = store_127900;
-        final com.github.krukow.clj_ds.PersistentMap<String, A_Method> result_out27500 = lifted_19640000;
-        return new R_default_MM(result_out27500, store_out27500);
+        final com.github.krukow.clj_ds.PersistentMap<?, ?> lifted_44370000 = (com.github.krukow.clj_ds.PersistentMap<?, ?>)PersistentTreeMap.EMPTY;
+        final com.github.krukow.clj_ds.PersistentMap<String, A_Method> lifted_44360000 = (com.github.krukow.clj_ds.PersistentMap<String, A_Method>)lifted_44370000;
+        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out25100 = l_int_v_125500;
+        final com.github.krukow.clj_ds.PersistentMap<String, A_Method> result_out52900 = lifted_44360000;
+        return new R_default_Map_String_Method_(result_out52900, l_int_v_out25100);
       }
       else
       { 
-        if(lifted_19660000 != null && !lifted_19660000.isEmpty())
+        if(lifted_44380000 != null && !lifted_44380000.isEmpty())
         { 
-          final A_Method m5300000 = lifted_19660000.head();
-          final L_A_Method ms6200000 = lifted_19660000.tail();
-          final Method_4 $tmp555 = m5300000.match(Method_4.class);
-          if($tmp555 != null)
+          final A_Method m174000000 = lifted_44380000.head();
+          final L_A_Method ms231000000 = lifted_44380000.tail();
+          final Method_4 $tmp1019 = m174000000.match(Method_4.class);
+          if($tmp1019 != null)
           { 
-            final A_Type lifted_18490000 = $tmp555.get_1();
-            final String name4500000 = $tmp555.get_2();
-            final L_A_Param lifted_18510000 = $tmp555.get_3();
-            final A_Block lifted_18520000 = $tmp555.get_4();
-            final initMethods_1 lifted_19690000 = new initMethods_1(this.getSourceInfo(), ms6200000);
-            final R_default_MM $tmp556 = lifted_19690000.exec_default(this_120300, env_127900, c_132800, store_127900);
-            final com.github.krukow.clj_ds.PersistentMap<String, A_Method> lifted_2128000 = $tmp556.value;
-            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_219900 = $tmp556.get_1();
-            final com.github.krukow.clj_ds.PersistentMap<String, A_Method> lifted_19670000 = MapUtils.plus(lifted_2128000, new com.github.krukow.clj_lang.PersistentTreeMap<String, A_Method>().plus(name4500000, m5300000));
-            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out27500 = store_219900;
-            final com.github.krukow.clj_ds.PersistentMap<String, A_Method> result_out27500 = lifted_19670000;
-            return new R_default_MM(result_out27500, store_out27500);
+            final A_Type lifted_43320000 = $tmp1019.get_1();
+            final String name513000000 = $tmp1019.get_2();
+            final L_A_Param lifted_43330000 = $tmp1019.get_3();
+            final A_Block lifted_43340000 = $tmp1019.get_4();
+            final com.github.krukow.clj_ds.PersistentMap<String, A_Method> lifted_44410000 = new com.github.krukow.clj_lang.PersistentTreeMap<String, A_Method>().plus(name513000000, m174000000);
+            final initMethods_1 lifted_44420000 = new initMethods_1(this.getSourceInfo(), ms231000000);
+            final R_default_Map_String_Method_ $tmp1020 = lifted_44420000.exec_default(l_string_class_124000, l_string_v_125500, this_122600, l_int_v_125500);
+            final com.github.krukow.clj_ds.PersistentMap<String, A_Method> lifted_4594000 = $tmp1020.value;
+            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_218900 = $tmp1020.get_1();
+            final com.github.krukow.clj_ds.PersistentMap<String, A_Method> lifted_44390000 = MapUtils.plus(lifted_4594000, lifted_44410000);
+            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out25100 = l_int_v_218900;
+            final com.github.krukow.clj_ds.PersistentMap<String, A_Method> result_out52900 = lifted_44390000;
+            return new R_default_Map_String_Method_(result_out52900, l_int_v_out25100);
           }
           else
           { }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/initObject_1.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/initObject_1.java
@@ -58,42 +58,42 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_Obj exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_Obj exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in19100 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in27200 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in27200 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in27200 = _4;
-    final A_Class lifted_19570000 = this._1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in22700 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in24900 = _2;
+    final A_This this_in21400 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in24900 = _4;
+    final A_Class lifted_44300000 = this._1;
     { 
-      final A_This this_119900 = this_in19100;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_127600 = env_in27200;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_132400 = c_in27200;
-      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_127600 = store_in27200;
-      final Class_4 $tmp543 = lifted_19570000.match(Class_4.class);
-      if($tmp543 != null)
+      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_123700 = l_string_class_in22700;
+      final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_125200 = l_string_v_in24900;
+      final A_This this_122300 = this_in21400;
+      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_125200 = l_int_v_in24900;
+      final Class_4 $tmp1007 = lifted_44300000.match(Class_4.class);
+      if($tmp1007 != null)
       { 
-        final String c17600000 = $tmp543.get_1();
-        final A_Extends ext1500000 = $tmp543.get_2();
-        final L_A_Field fs6100000 = $tmp543.get_3();
-        final L_A_Method ms6100000 = $tmp543.get_4();
-        final initSuper_1 lifted_19590000 = new initSuper_1(this.getSourceInfo(), ext1500000);
-        final initFields_1 lifted_19610000 = new initFields_1(this.getSourceInfo(), fs6100000);
-        final initMethods_1 lifted_19620000 = new initMethods_1(this.getSourceInfo(), ms6100000);
-        final R_default_Super $tmp544 = lifted_19590000.exec_default(this_119900, env_127600, c_132400, store_127600);
-        final A_Super lifted_2122000 = $tmp544.value;
-        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_219600 = $tmp544.get_1();
-        final R_default_FM $tmp545 = lifted_19610000.exec_default(this_119900, env_127600, c_132400, store_219600);
-        final com.github.krukow.clj_ds.PersistentMap<String, Integer> lifted_2123000 = $tmp545.value;
-        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_312400 = $tmp545.get_1();
-        final R_default_MM $tmp546 = lifted_19620000.exec_default(this_119900, env_127600, c_132400, store_312400);
-        final com.github.krukow.clj_ds.PersistentMap<String, A_Method> lifted_2124000 = $tmp546.value;
-        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_42800 = $tmp546.get_1();
-        final ObjV_4 lifted_19580000 = new ObjV_4(this.getSourceInfo(), c17600000, lifted_2122000, lifted_2123000, lifted_2124000);
-        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out27200 = store_42800;
-        final A_Obj result_out27200 = lifted_19580000;
-        return new R_default_Obj(result_out27200, store_out27200);
+        final String c1273000000 = $tmp1007.get_1();
+        final A_Extends ext56000000 = $tmp1007.get_2();
+        final L_A_Field fs226000000 = $tmp1007.get_3();
+        final L_A_Method ms230000000 = $tmp1007.get_4();
+        final initSuper_1 lifted_44320000 = new initSuper_1(this.getSourceInfo(), ext56000000);
+        final initFields_1 lifted_44330000 = new initFields_1(this.getSourceInfo(), fs226000000);
+        final initMethods_1 lifted_44340000 = new initMethods_1(this.getSourceInfo(), ms230000000);
+        final R_default_Super $tmp1008 = lifted_44320000.exec_default(l_string_class_123700, l_string_v_125200, this_122300, l_int_v_125200);
+        final A_Super lifted_4588000 = $tmp1008.value;
+        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_218600 = $tmp1008.get_1();
+        final R_default_Map_String_Int_ $tmp1009 = lifted_44330000.exec_default(l_string_class_123700, l_string_v_125200, this_122300, l_int_v_218600);
+        final com.github.krukow.clj_ds.PersistentMap<String, Integer> lifted_4589000 = $tmp1009.value;
+        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_311500 = $tmp1009.get_1();
+        final R_default_Map_String_Method_ $tmp1010 = lifted_44340000.exec_default(l_string_class_123700, l_string_v_125200, this_122300, l_int_v_311500);
+        final com.github.krukow.clj_ds.PersistentMap<String, A_Method> lifted_4590000 = $tmp1010.value;
+        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_42600 = $tmp1010.get_1();
+        final ObjV_4 lifted_44310000 = new ObjV_4(this.getSourceInfo(), c1273000000, lifted_4588000, lifted_4589000, lifted_4590000);
+        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out24800 = l_int_v_42600;
+        final A_Obj result_out52600 = lifted_44310000;
+        return new R_default_Obj(result_out52600, l_int_v_out24800);
       }
       else
       { }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/initSuper_1.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/initSuper_1.java
@@ -58,45 +58,45 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_Super exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_Super exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in19200 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in27300 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in27300 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in27300 = _4;
-    final A_Extends lifted_19540000 = this._1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in22800 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in25000 = _2;
+    final A_This this_in21500 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in25000 = _4;
+    final A_Extends lifted_44270000 = this._1;
     { 
-      final A_This this_120100 = this_in19200;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_127700 = env_in27300;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_132500 = c_in27300;
-      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_127700 = store_in27300;
-      final NoExtends_0 $tmp547 = lifted_19540000.match(NoExtends_0.class);
-      if($tmp547 != null)
+      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_123800 = l_string_class_in22800;
+      final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_125300 = l_string_v_in25000;
+      final A_This this_122400 = this_in21500;
+      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_125300 = l_int_v_in25000;
+      final NoExtends_0 $tmp1011 = lifted_44270000.match(NoExtends_0.class);
+      if($tmp1011 != null)
       { 
-        final NoSuper_0 lifted_19530000 = new NoSuper_0(this.getSourceInfo());
-        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out27300 = store_127700;
-        final A_Super result_out27300 = lifted_19530000;
-        return new R_default_Super(result_out27300, store_out27300);
+        final NoSuper_0 lifted_44260000 = new NoSuper_0(this.getSourceInfo());
+        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out24900 = l_int_v_125300;
+        final A_Super result_out52700 = lifted_44260000;
+        return new R_default_Super(result_out52700, l_int_v_out24900);
       }
       else
       { 
-        final Extends_1 $tmp548 = lifted_19540000.match(Extends_1.class);
-        if($tmp548 != null)
+        final Extends_1 $tmp1012 = lifted_44270000.match(Extends_1.class);
+        if($tmp1012 != null)
         { 
-          final String c17500000 = $tmp548.get_1();
-          final loadClass_1 lifted_19560000 = new loadClass_1(this.getSourceInfo(), c17500000);
-          final R_default_Class $tmp549 = lifted_19560000.exec_default(this_120100, env_127700, c_132500, store_127700);
-          final A_Class lifted_2117000 = $tmp549.value;
-          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_219700 = $tmp549.get_1();
-          final initObject_1 lifted_19550000 = new initObject_1(this.getSourceInfo(), lifted_2117000);
-          final R_default_Obj $tmp550 = lifted_19550000.exec_default(this_120100, env_127700, c_132500, store_219700);
-          final A_Obj lifted_2120000 = $tmp550.value;
-          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_312500 = $tmp550.get_1();
-          final Super_1 lifted_2119000 = new Super_1(this.getSourceInfo(), lifted_2120000);
-          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out27300 = store_312500;
-          final A_Super result_out27300 = lifted_2119000;
-          return new R_default_Super(result_out27300, store_out27300);
+          final String c1272000000 = $tmp1012.get_1();
+          final loadClass_1 lifted_44290000 = new loadClass_1(this.getSourceInfo(), c1272000000);
+          final R_default_Class $tmp1013 = lifted_44290000.exec_default(l_string_class_123800, l_string_v_125300, this_122400, l_int_v_125300);
+          final A_Class lifted_4583000 = $tmp1013.value;
+          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_218700 = $tmp1013.get_1();
+          final initObject_1 lifted_44280000 = new initObject_1(this.getSourceInfo(), lifted_4583000);
+          final R_default_Obj $tmp1014 = lifted_44280000.exec_default(l_string_class_123800, l_string_v_125300, this_122400, l_int_v_218700);
+          final A_Obj lifted_4586000 = $tmp1014.value;
+          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_311600 = $tmp1014.get_1();
+          final Super_1 lifted_4585000 = new Super_1(this.getSourceInfo(), lifted_4586000);
+          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out24900 = l_int_v_311600;
+          final A_Super result_out52700 = lifted_4585000;
+          return new R_default_Super(result_out52700, l_int_v_out24900);
         }
         else
         { }

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/loadClass_1.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/loadClass_1.java
@@ -54,22 +54,22 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_Class exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_Class exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in18800 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in26900 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in26900 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in26900 = _4;
-    final String c17400000 = this._1;
-    final A_This this_119700 = this_in18800;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_127400 = env_in26900;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> C1500000 = c_in26900;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_127400 = store_in26900;
-    final A_Class lifted_19420000 = C1500000.get(c17400000);
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out26900 = store_127400;
-    final A_Class result_out26900 = lifted_19420000;
-    return new R_default_Class(result_out26900, store_out26900);
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in22500 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in24700 = _2;
+    final A_This this_in20800 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in24700 = _4;
+    final String c1271000000 = this._1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> C56000000 = l_string_class_in22500;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_125000 = l_string_v_in24700;
+    final A_This this_122100 = this_in20800;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_125000 = l_int_v_in24700;
+    final A_Class lifted_44160000 = C56000000.get(c1271000000);
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out24600 = l_int_v_125000;
+    final A_Class result_out52400 = lifted_44160000;
+    return new R_default_Class(result_out52400, l_int_v_out24600);
   }
 
   public String get_1()
@@ -79,7 +79,7 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)
   { 
-    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("loadClass", 1), factory.makeString(_1));
+    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("loadClass", 1), TermUtils.termFromString(_1, factory));
     if(getSourceInfo() != null)
     { 
       getSourceInfo().apply(term);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/lookupField_3.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/lookupField_3.java
@@ -88,52 +88,52 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_Int exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_Int exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in19800 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in27900 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in27900 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in27900 = _4;
-    final A_Obj lifted_19380000 = this._1;
-    final String c23700000 = this._2;
-    final String f9100000 = this._3;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in23400 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in25600 = _2;
+    final A_This this_in22300 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in25600 = _4;
+    final A_Obj lifted_44130000 = this._1;
+    final String c2115000000 = this._2;
+    final String f1202000000 = this._3;
     { 
-      final A_This this_120700 = this_in19800;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_128400 = env_in27900;
-      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_133300 = c_in27900;
-      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_128400 = store_in27900;
-      final ObjV_4 $tmp564 = lifted_19380000.match(ObjV_4.class);
-      if($tmp564 != null)
+      final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_124400 = l_string_class_in23400;
+      final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_125900 = l_string_v_in25600;
+      final A_This this_123100 = this_in22300;
+      final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_125900 = l_int_v_in25600;
+      final ObjV_4 $tmp1028 = lifted_44130000.match(ObjV_4.class);
+      if($tmp1028 != null)
       { 
-        final String c17300000 = $tmp564.get_1();
-        final A_Super sup6200000 = $tmp564.get_2();
-        final com.github.krukow.clj_ds.PersistentMap<String, Integer> fs5900000 = $tmp564.get_3();
-        final com.github.krukow.clj_ds.PersistentMap<String, A_Method> lifted_18470000 = $tmp564.get_4();
-        if(c17300000 != null && c17300000.equals(c23700000))
+        final String c1269000000 = $tmp1028.get_1();
+        final A_Super sup231000000 = $tmp1028.get_2();
+        final com.github.krukow.clj_ds.PersistentMap<String, Integer> fs225000000 = $tmp1028.get_3();
+        final com.github.krukow.clj_ds.PersistentMap<String, A_Method> lifted_43300000 = $tmp1028.get_4();
+        if(c1269000000 != null && c1269000000.equals(c2115000000))
         { 
-          final int lifted_19370000 = fs5900000.get(f9100000);
-          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out27900 = store_128400;
-          final int result_out27900 = lifted_19370000;
-          return new R_default_Int(result_out27900, store_out27900);
+          final int lifted_44120000 = fs225000000.get(f1202000000);
+          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out25500 = l_int_v_125900;
+          final int result_out53300 = lifted_44120000;
+          return new R_default_Int(result_out53300, l_int_v_out25500);
         }
         else
         { 
-          if(c17300000 != null && c17300000.equals(c23700000))
+          if(c1269000000 != null && c1269000000.equals(c2115000000))
           { }
           else
           { 
-            final Super_1 $tmp565 = sup6200000.match(Super_1.class);
-            if($tmp565 != null)
+            final Super_1 $tmp1029 = sup231000000.match(Super_1.class);
+            if($tmp1029 != null)
             { 
-              final A_Obj o9100000 = $tmp565.get_1();
-              final lookupField_3 lifted_19390000 = new lookupField_3(this.getSourceInfo(), o9100000, c23700000, f9100000);
-              final R_default_Int $tmp566 = lifted_19390000.exec_default(this_120700, env_128400, c_133300, store_128400);
-              final int lifted_2111000 = $tmp566.value;
-              final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_220300 = $tmp566.get_1();
-              final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out27900 = store_220300;
-              final int result_out27900 = lifted_2111000;
-              return new R_default_Int(result_out27900, store_out27900);
+              final A_Obj o605000000 = $tmp1029.get_1();
+              final lookupField_3 lifted_44140000 = new lookupField_3(this.getSourceInfo(), o605000000, c2115000000, f1202000000);
+              final R_default_Int $tmp1030 = lifted_44140000.exec_default(l_string_class_124400, l_string_v_125900, this_123100, l_int_v_125900);
+              final int lifted_4577000 = $tmp1030.value;
+              final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_219200 = $tmp1030.get_1();
+              final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out25500 = l_int_v_219200;
+              final int result_out53300 = lifted_4577000;
+              return new R_default_Int(result_out53300, l_int_v_out25500);
             }
             else
             { }
@@ -165,7 +165,7 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)
   { 
-    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("lookupField", 3), _1.toStrategoTerm(factory), factory.makeString(_2), factory.makeString(_3));
+    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("lookupField", 3), _1.toStrategoTerm(factory), TermUtils.termFromString(_2, factory), TermUtils.termFromString(_3, factory));
     if(getSourceInfo() != null)
     { 
       getSourceInfo().apply(term);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/lookupMethod_2.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/lookupMethod_2.java
@@ -73,59 +73,59 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_Method exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_Method exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in19900 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in28100 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in28100 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in28100 = _4;
-    final A_Obj lifted_19320000 = this._1;
-    final String name4400000 = this._2;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in23500 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in25700 = _2;
+    final A_This this_in22400 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in25700 = _4;
+    final A_Obj lifted_44070000 = this._1;
+    final String name512000000 = this._2;
     { 
       { 
-        final A_This this_120800 = this_in19900;
-        final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_128500 = env_in28100;
-        final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_133400 = c_in28100;
-        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_128500 = store_in28100;
-        final ObjV_4 $tmp567 = lifted_19320000.match(ObjV_4.class);
-        if($tmp567 != null)
+        final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_124500 = l_string_class_in23500;
+        final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_126000 = l_string_v_in25700;
+        final A_This this_123200 = this_in22400;
+        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_126000 = l_int_v_in25700;
+        final ObjV_4 $tmp1031 = lifted_44070000.match(ObjV_4.class);
+        if($tmp1031 != null)
         { 
-          final String c16900000 = $tmp567.get_1();
-          final A_Super sup5800000 = $tmp567.get_2();
-          final com.github.krukow.clj_ds.PersistentMap<String, Integer> lifted_18440000 = $tmp567.get_3();
-          final com.github.krukow.clj_ds.PersistentMap<String, A_Method> ms5800000 = $tmp567.get_4();
-          final A_Method m5100000 = ms5800000.get(name4400000);
-          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out28100 = store_128500;
-          final A_Method result_out28100 = m5100000;
-          return new R_default_Method(result_out28100, store_out28100);
+          final String c1266000000 = $tmp1031.get_1();
+          final A_Super sup228000000 = $tmp1031.get_2();
+          final com.github.krukow.clj_ds.PersistentMap<String, Integer> lifted_43270000 = $tmp1031.get_3();
+          final com.github.krukow.clj_ds.PersistentMap<String, A_Method> ms228000000 = $tmp1031.get_4();
+          final A_Method m172000000 = ms228000000.get(name512000000);
+          final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out25600 = l_int_v_126000;
+          final A_Method result_out53400 = m172000000;
+          return new R_default_Method(result_out53400, l_int_v_out25600);
         }
         else
         { }
       }
       { 
-        final A_This this_120900 = this_in19900;
-        final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_128600 = env_in28100;
-        final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_133500 = c_in28100;
-        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_128600 = store_in28100;
-        final ObjV_4 $tmp568 = lifted_19320000.match(ObjV_4.class);
-        if($tmp568 != null)
+        final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_124600 = l_string_class_in23500;
+        final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_126100 = l_string_v_in25700;
+        final A_This this_123300 = this_in22400;
+        final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_126100 = l_int_v_in25700;
+        final ObjV_4 $tmp1032 = lifted_44070000.match(ObjV_4.class);
+        if($tmp1032 != null)
         { 
-          final String c17100000 = $tmp568.get_1();
-          final A_Super sup5900000 = $tmp568.get_2();
-          final com.github.krukow.clj_ds.PersistentMap<String, Integer> lifted_18450000 = $tmp568.get_3();
-          final com.github.krukow.clj_ds.PersistentMap<String, A_Method> ms5900000 = $tmp568.get_4();
-          final Super_1 $tmp569 = sup5900000.match(Super_1.class);
-          if($tmp569 != null)
+          final String c1267000000 = $tmp1032.get_1();
+          final A_Super sup229000000 = $tmp1032.get_2();
+          final com.github.krukow.clj_ds.PersistentMap<String, Integer> lifted_43280000 = $tmp1032.get_3();
+          final com.github.krukow.clj_ds.PersistentMap<String, A_Method> ms229000000 = $tmp1032.get_4();
+          final Super_1 $tmp1033 = sup229000000.match(Super_1.class);
+          if($tmp1033 != null)
           { 
-            final A_Obj o8900000 = $tmp569.get_1();
-            final lookupMethod_2 lifted_19340000 = new lookupMethod_2(this.getSourceInfo(), o8900000, name4400000);
-            final R_default_Method $tmp570 = lifted_19340000.exec_default(this_120900, env_128600, c_133500, store_128600);
-            final A_Method lifted_2109000 = $tmp570.value;
-            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_220400 = $tmp570.get_1();
-            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out28100 = store_220400;
-            final A_Method result_out28100 = lifted_2109000;
-            return new R_default_Method(result_out28100, store_out28100);
+            final A_Obj o604000000 = $tmp1033.get_1();
+            final lookupMethod_2 lifted_44090000 = new lookupMethod_2(this.getSourceInfo(), o604000000, name512000000);
+            final R_default_Method $tmp1034 = lifted_44090000.exec_default(l_string_class_124600, l_string_v_126100, this_123300, l_int_v_126100);
+            final A_Method lifted_4575000 = $tmp1034.value;
+            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_219300 = $tmp1034.get_1();
+            final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out25600 = l_int_v_219300;
+            final A_Method result_out53400 = lifted_4575000;
+            return new R_default_Method(result_out53400, l_int_v_out25600);
           }
           else
           { }
@@ -151,7 +151,7 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)
   { 
-    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("lookupMethod", 2), _1.toStrategoTerm(factory), factory.makeString(_2));
+    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("lookupMethod", 2), _1.toStrategoTerm(factory), TermUtils.termFromString(_2, factory));
     if(getSourceInfo() != null)
     { 
       getSourceInfo().apply(term);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/readField_3.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/readField_3.java
@@ -88,31 +88,31 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in19600 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in27700 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in27700 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in27700 = _4;
-    final A_Obj o8800000 = this._1;
-    final String c16700000 = this._2;
-    final String f8800000 = this._3;
-    final A_This this_120500 = this_in19600;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_128200 = env_in27700;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_133100 = c_in27700;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_128200 = store_in27700;
-    final lookupField_3 lifted_18890000 = new lookupField_3(this.getSourceInfo(), o8800000, c16700000, f8800000);
-    final R_default_Int $tmp560 = lifted_18890000.exec_default(this_120500, env_128200, c_133100, store_128200);
-    final int lifted_2083000 = $tmp560.value;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_220100 = $tmp560.get_1();
-    final read_1 lifted_18880000 = new read_1(this.getSourceInfo(), lifted_2083000);
-    final R_default_V $tmp561 = lifted_18880000.exec_default(this_120500, env_128200, c_133100, store_220100);
-    final A_V lifted_2085000 = $tmp561.value;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_312700 = $tmp561.get_1();
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out27700 = store_312700;
-    final A_V result_out27700 = lifted_2085000;
-    return new R_default_V(result_out27700, store_out27700);
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in23200 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in25400 = _2;
+    final A_This this_in21900 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in25400 = _4;
+    final A_Obj o603000000 = this._1;
+    final String c1264000000 = this._2;
+    final String f1200000000 = this._3;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_124200 = l_string_class_in23200;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_125700 = l_string_v_in25400;
+    final A_This this_122800 = this_in21900;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_125700 = l_int_v_in25400;
+    final lookupField_3 lifted_43700000 = new lookupField_3(this.getSourceInfo(), o603000000, c1264000000, f1200000000);
+    final R_default_Int $tmp1024 = lifted_43700000.exec_default(l_string_class_124200, l_string_v_125700, this_122800, l_int_v_125700);
+    final int lifted_4551000 = $tmp1024.value;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_219000 = $tmp1024.get_1();
+    final read_1 lifted_43690000 = new read_1(this.getSourceInfo(), lifted_4551000);
+    final R_default_V $tmp1025 = lifted_43690000.exec_default(l_string_class_124200, l_string_v_125700, this_122800, l_int_v_219000);
+    final A_V lifted_4553000 = $tmp1025.value;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_311800 = $tmp1025.get_1();
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out25300 = l_int_v_311800;
+    final A_V result_out53100 = lifted_4553000;
+    return new R_default_V(result_out53100, l_int_v_out25300);
   }
 
   public A_Obj get_1()
@@ -132,7 +132,7 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)
   { 
-    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("readField", 3), _1.toStrategoTerm(factory), factory.makeString(_2), factory.makeString(_3));
+    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("readField", 3), _1.toStrategoTerm(factory), TermUtils.termFromString(_2, factory), TermUtils.termFromString(_3, factory));
     if(getSourceInfo() != null)
     { 
       getSourceInfo().apply(term);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/readVar_1.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/readVar_1.java
@@ -54,22 +54,22 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in22900 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in30900 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in30900 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in30900 = _4;
-    final String x51200000 = this._1;
-    final A_This this_123800 = this_in22900;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> E4400000 = env_in30900;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_137600 = c_in30900;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_131600 = store_in30900;
-    final A_V lifted_18860000 = E4400000.get(x51200000);
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out30900 = store_131600;
-    final A_V result_out30900 = lifted_18860000;
-    return new R_default_V(result_out30900, store_out30900);
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in26100 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in28300 = _2;
+    final A_This this_in25400 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in28300 = _4;
+    final String x593000000 = this._1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_127200 = l_string_class_in26100;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> E46000000 = l_string_v_in28300;
+    final A_This this_126100 = this_in25400;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_128700 = l_int_v_in28300;
+    final A_V lifted_43670000 = E46000000.get(x593000000);
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out28200 = l_int_v_128700;
+    final A_V result_out56000 = lifted_43670000;
+    return new R_default_V(result_out56000, l_int_v_out28200);
   }
 
   public String get_1()
@@ -79,7 +79,7 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)
   { 
-    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("readVar", 1), factory.makeString(_1));
+    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("readVar", 1), TermUtils.termFromString(_1, factory));
     if(getSourceInfo() != null)
     { 
       getSourceInfo().apply(term);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/read_1.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/read_1.java
@@ -46,22 +46,22 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in23400 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in31500 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in31500 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in31500 = _4;
-    final int loc4500000 = this._1;
-    final A_This this_124300 = this_in23400;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_131800 = env_in31500;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_138100 = c_in31500;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> S3100000 = store_in31500;
-    final A_V lifted_18910000 = S3100000.get(loc4500000);
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out31500 = S3100000;
-    final A_V result_out31500 = lifted_18910000;
-    return new R_default_V(result_out31500, store_out31500);
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in26500 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in28700 = _2;
+    final A_This this_in25800 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in28700 = _4;
+    final int loc41000000 = this._1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_127600 = l_string_class_in26500;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_128900 = l_string_v_in28700;
+    final A_This this_126500 = this_in25800;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> S27000000 = l_int_v_in28700;
+    final A_V lifted_43710000 = S27000000.get(loc41000000);
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out28600 = S27000000;
+    final A_V result_out56400 = lifted_43710000;
+    return new R_default_V(result_out56400, l_int_v_out28600);
   }
 
   public int get_1()
@@ -71,7 +71,7 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)
   { 
-    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("read", 1), factory.makeInt(_1));
+    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("read", 1), TermUtils.termFromInt(_1, factory));
     if(getSourceInfo() != null)
     { 
       getSourceInfo().apply(term);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/writeField_4.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/writeField_4.java
@@ -107,32 +107,32 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in19700 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in27800 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in27800 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in27800 = _4;
-    final A_Obj o8500000 = this._1;
-    final String c16500000 = this._2;
-    final String f8600000 = this._3;
-    final A_V v14900000 = this._4;
-    final A_This this_120600 = this_in19700;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_128300 = env_in27800;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_133200 = c_in27800;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_128300 = store_in27800;
-    final lookupField_3 lifted_18710000 = new lookupField_3(this.getSourceInfo(), o8500000, c16500000, f8600000);
-    final R_default_Int $tmp562 = lifted_18710000.exec_default(this_120600, env_128300, c_133200, store_128300);
-    final int lifted_2066000 = $tmp562.value;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_220200 = $tmp562.get_1();
-    final write_2 lifted_18690000 = new write_2(this.getSourceInfo(), lifted_2066000, v14900000);
-    final R_default_V $tmp563 = lifted_18690000.exec_default(this_120600, env_128300, c_133200, store_220200);
-    final A_V lifted_2068000 = $tmp563.value;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_312800 = $tmp563.get_1();
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out27800 = store_312800;
-    final A_V result_out27800 = lifted_2068000;
-    return new R_default_V(result_out27800, store_out27800);
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in23300 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in25500 = _2;
+    final A_This this_in22200 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in25500 = _4;
+    final A_Obj o600000000 = this._1;
+    final String c1262000000 = this._2;
+    final String f1198000000 = this._3;
+    final A_V v1179000000 = this._4;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_124300 = l_string_class_in23300;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_125800 = l_string_v_in25500;
+    final A_This this_122900 = this_in22200;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_125800 = l_int_v_in25500;
+    final lookupField_3 lifted_43510000 = new lookupField_3(this.getSourceInfo(), o600000000, c1262000000, f1198000000);
+    final R_default_Int $tmp1026 = lifted_43510000.exec_default(l_string_class_124300, l_string_v_125800, this_122900, l_int_v_125800);
+    final int lifted_4535000 = $tmp1026.value;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_219100 = $tmp1026.get_1();
+    final write_2 lifted_43500000 = new write_2(this.getSourceInfo(), lifted_4535000, v1179000000);
+    final R_default_V $tmp1027 = lifted_43500000.exec_default(l_string_class_124300, l_string_v_125800, this_122900, l_int_v_219100);
+    final A_V lifted_4537000 = $tmp1027.value;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_311900 = $tmp1027.get_1();
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out25400 = l_int_v_311900;
+    final A_V result_out53200 = lifted_4537000;
+    return new R_default_V(result_out53200, l_int_v_out25400);
   }
 
   public A_Obj get_1()
@@ -157,7 +157,7 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)
   { 
-    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("writeField", 4), _1.toStrategoTerm(factory), factory.makeString(_2), factory.makeString(_3), _4.toStrategoTerm(factory));
+    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("writeField", 4), _1.toStrategoTerm(factory), TermUtils.termFromString(_2, factory), TermUtils.termFromString(_3, factory), _4.toStrategoTerm(factory));
     if(getSourceInfo() != null)
     { 
       getSourceInfo().apply(term);

--- a/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/write_2.java
+++ b/languages/paplj/paplj.full/editor/java/ds/generated/interpreter/write_2.java
@@ -65,23 +65,24 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
     }
   }
 
-  public R_default_V exec_default(A_This _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, com.github.krukow.clj_ds.PersistentMap<String, A_Class> _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
+  public R_default_V exec_default(com.github.krukow.clj_ds.PersistentMap<String, A_Class> _1, com.github.krukow.clj_ds.PersistentMap<String, A_V> _2, A_This _3, com.github.krukow.clj_ds.PersistentMap<Integer, A_V> _4)
   { 
     this.specializeChildren(0);
-    final A_This this_in23300 = _1;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_in31400 = _2;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_in31400 = _3;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_in31400 = _4;
-    final int loc4400000 = this._1;
-    final A_V v15100000 = this._2;
-    final A_This this_124200 = this_in23300;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_V> env_131700 = env_in31400;
-    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> c_137900 = c_in31400;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> S2900000 = store_in31400;
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> lifted_18730000 = MapUtils.plus(S2900000, new com.github.krukow.clj_lang.PersistentTreeMap<Integer, A_V>().plus(loc4400000, v15100000));
-    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> store_out31400 = lifted_18730000;
-    final A_V result_out31400 = v15100000;
-    return new R_default_V(result_out31400, store_out31400);
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_in26400 = _1;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_in28600 = _2;
+    final A_This this_in25700 = _3;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_in28600 = _4;
+    final int loc40000000 = this._1;
+    final A_V v1180000000 = this._2;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_Class> l_string_class_127500 = l_string_class_in26400;
+    final com.github.krukow.clj_ds.PersistentMap<String, A_V> l_string_v_128800 = l_string_v_in28600;
+    final A_This this_126400 = this_in25700;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> S26000000 = l_int_v_in28600;
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> lifted_43540000 = new com.github.krukow.clj_lang.PersistentTreeMap<Integer, A_V>().plus(loc40000000, v1180000000);
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> lifted_43530000 = MapUtils.plus(S26000000, lifted_43540000);
+    final com.github.krukow.clj_ds.PersistentMap<Integer, A_V> l_int_v_out28500 = lifted_43530000;
+    final A_V result_out56300 = v1180000000;
+    return new R_default_V(result_out56300, l_int_v_out28500);
   }
 
   public int get_1()
@@ -96,7 +97,7 @@ import com.github.krukow.clj_lang.PersistentTreeMap;
 
   @Override public IStrategoTerm toStrategoTerm(ITermFactory factory)
   { 
-    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("write", 2), factory.makeInt(_1), _2.toStrategoTerm(factory));
+    IStrategoAppl term = factory.makeAppl(factory.makeConstructor("write", 2), TermUtils.termFromInt(_1, factory), _2.toStrategoTerm(factory));
     if(getSourceInfo() != null)
     { 
       getSourceInfo().apply(term);

--- a/languages/paplj/paplj.full/editor/java/ds/manual/interpreter/Natives.java
+++ b/languages/paplj/paplj.full/editor/java/ds/manual/interpreter/Natives.java
@@ -2,10 +2,12 @@ package ds.manual.interpreter;
 
 import com.github.krukow.clj_ds.PersistentMap;
 
+import ds.generated.interpreter.A_This;
+
 public class Natives {
 
 	private static int fresh_counter = 1;
-	
+
 	public static String print_1(String s) {
 		System.err.println(s);
 		return s;
@@ -54,9 +56,12 @@ public class Natives {
 		return i1 > i2;
 	}
 
-	public static boolean isstored_2(PersistentMap<Integer, ?> map,
-			int loc) {
+	public static boolean isstored_2(PersistentMap<Integer, ?> map, int loc) {
 		return map.containsKey(loc);
+	}
+
+	public static A_This mkNullThis_0() {
+		return null;
 	}
 
 }

--- a/languages/paplj/paplj.full/editor/java/paplj/full/strategies/runprogram_0_0.java
+++ b/languages/paplj/paplj.full/editor/java/paplj/full/strategies/runprogram_0_0.java
@@ -4,8 +4,6 @@ import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.strategoxt.lang.Context;
 import org.strategoxt.lang.Strategy;
 
-import com.github.krukow.clj_lang.PersistentTreeMap;
-
 import ds.generated.interpreter.Generic_A_Program;
 
 public class runprogram_0_0 extends Strategy {
@@ -15,8 +13,7 @@ public class runprogram_0_0 extends Strategy {
 	@Override
 	public IStrategoTerm invoke(Context context, IStrategoTerm program) {
 
-		return new Generic_A_Program(null, program).exec_default(
-				PersistentTreeMap.EMPTY, PersistentTreeMap.EMPTY, null,
-				PersistentTreeMap.EMPTY).toStrategoTerm(context.getFactory());
+		return new Generic_A_Program(null, program).exec_init().toStrategoTerm(
+				context.getFactory());
 	}
 }

--- a/languages/paplj/paplj.full/editor/java/paplj/full/strategies/runprogram_0_0.java
+++ b/languages/paplj/paplj.full/editor/java/paplj/full/strategies/runprogram_0_0.java
@@ -15,8 +15,8 @@ public class runprogram_0_0 extends Strategy {
 	@Override
 	public IStrategoTerm invoke(Context context, IStrategoTerm program) {
 
-		return new Generic_A_Program(null, program).exec_default(null,
-				PersistentTreeMap.EMPTY, PersistentTreeMap.EMPTY, PersistentTreeMap.EMPTY)
-				.toStrategoTerm(context.getFactory());
+		return new Generic_A_Program(null, program).exec_default(
+				PersistentTreeMap.EMPTY, PersistentTreeMap.EMPTY, null,
+				PersistentTreeMap.EMPTY).toStrategoTerm(context.getFactory());
 	}
 }

--- a/languages/paplj/paplj.full/pom.xml
+++ b/languages/paplj/paplj.full/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.metaborg</groupId>
     <artifactId>org.metaborg.maven.parent.language</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.5.0-SNAPSHOT</version>
     <relativePath/>
   </parent>
 

--- a/languages/paplj/paplj.full/trans/semantics/runtime/environment.ds
+++ b/languages/paplj/paplj.full/trans/semantics/runtime/environment.ds
@@ -4,8 +4,8 @@ imports trans/semantics/runtime/values
 imports trans/semantics/signatures/Common-sig
 
 signature
-  aliases
-    Env : Map<String, V>  
+  sort aliases
+    Env = Map<String, V>  
   variables
     E : Env
   constructors

--- a/languages/paplj/paplj.full/trans/semantics/runtime/store.ds
+++ b/languages/paplj/paplj.full/trans/semantics/runtime/store.ds
@@ -4,8 +4,8 @@ imports trans/semantics/runtime/values
 imports trans/semantics/runtime/primitives
 
 signature
-  aliases
-    Store : Map<Int, V> 
+  sort aliases
+    Store = Map<Int, V> 
   variables 
     S : Store
   constructors

--- a/languages/paplj/paplj.full/trans/semantics/semantics.ds
+++ b/languages/paplj/paplj.full/trans/semantics/semantics.ds
@@ -1,4 +1,20 @@
 module trans/semantics/semantics
 
 imports trans/semantics/interpret
-              
+
+
+// Entry point
+
+signature
+  arrows
+    Program -_init-> V
+
+  native operators
+    mkNullThis: This
+
+rules
+  
+  p : Program -_init-> v
+  where
+    Map<String,Class> {}, Map<String, V> {}, This mkNullThis() |- p :: Map<Int, V> {} --> v :: Map<Int, V> _.    
+

--- a/languages/paplj/paplj.full/trans/semantics/values.ds
+++ b/languages/paplj/paplj.full/trans/semantics/values.ds
@@ -16,13 +16,13 @@ signature // basic values
 // of method table?
  
 signature // representation of Class at run-time 
-  aliases
-    ClassMap : Map<String, Class>
+  sort aliases
+    C = Map<String, Class>
   constructors    
     loadClass   : String --> Class
-    initClasses : List(Class) --> ClassMap
+    initClasses : List(Class) --> C
   variables
-    C : ClassMap
+    C : C
     
 rules
 
@@ -33,9 +33,9 @@ rules
 
 signature // object values
   sorts Obj Super FieldSet 
-  aliases
-    FM : Map<String, Int> 
-    MM : Map<String, Method>   
+  sort aliases
+    FM = Map<String, Int> 
+    MM = Map<String, Method>   
   variables
     FM : FM
     MM : MM
@@ -70,8 +70,8 @@ rules
   initSuper(Extends(c)) --> initObject(loadClass(c)).
 
   initFields([]) --> {}.
-  initFields([Field(t, f) | fs]) --> {f |--> allocate(v), FM}
-  where defaultValue(t) --> v; initFields(fs) --> FM.
+  initFields([Field(t, f) | fs]) --> {f |--> addr, FM}
+  where defaultValue(t) --> v; initFields(fs) --> FM; allocate(v) --> addr.
   
   defaultValue(NumT()) --> NumV(0).
   defaultValue(BoolT()) --> BoolV(false).


### PR DESCRIPTION
Update semantics specification of PaplJ.full to the new sort aliases syntax that DynSem received in PR metaborg/dynsem@0b660bc2ee45172d5066b03fd31069ad2fc606a6.

And update semantics of PaplJ.full to use the `-ini->` arrow for injection a program into a valid configuration.

Also update the generated interpreter for PaplJ.full.
